### PR TITLE
Develop

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,9 @@
 WIFI_SSID=YourWiFiNetworkName
 WIFI_PASSWORD=YourWiFiPassword
 
+# MCP API authentication credentials are configured in include/settings.h
+# (MCP_API_USER / MCP_API_PASSWORD). Leave MCP_API_USER empty for open access.
+
 # Notes:
 # - Use quotes around values, especially if they contain spaces or special characters
 # - No spaces around the = sign

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-      
+    timeout-minutes: 5
+
     strategy:
       matrix:
         environment: [esp32cam-release, esp32cam-debug]

--- a/PROJECT_DOCS.md
+++ b/PROJECT_DOCS.md
@@ -169,6 +169,29 @@ The camera lens should face the target while the small flash LED (adjacent to th
 
 Serial debugging throughout the application using the log_ macros
 
+## GPIO Tool Documentation
+
+### Complete Parameter Reference
+
+The `gpio` tool controls the GPIO pins of the ESP32-CAM. Valid pins are **GPIO2, GPIO12, GPIO13, GPIO14, and GPIO15**. Each pin can be configured in one of four modes:
+
+#### Modes
+
+- **`di`** (digital input) — Configures the pin as a digital input. Returns `value` as `true`/`false` depending on the logical level of the pin.
+- **`ai`** (analog input) — Configures the pin as an analog input. Uses the ADC calibration helper functions (`analogReadMilliVolts`) for a linear reading, and returns `value` as the percentage (0-100) of the max input (3.3V).
+- **`do`** (digital output) — Configures the pin as a digital output. Accepts `value` `true`/`false` and sets the pin to the corresponding logical level.
+- **`ao`** (analog output) — Configures the pin as a PWM (analog) output. Accepts `value` `0-100` as the duty cycle percentage.
+
+#### Implementation Details
+
+- Each pin is mapped to a dedicated LEDC channel (10-15) for analog output, using high-speed group 1 (timers 1-3). These never collide with the camera's XCLK PWM, which uses low-speed group 0 (timer 0 or 1, channel 0 or 1).
+- Analog output uses 5000 Hz with 8-bit resolution (duty 0-255), set from the requested percentage.
+- Analog input expresses the calibrated millivolt reading as a percentage of the 3300 mV reference.
+
+#### Known Limitations
+
+- All valid pins are ADC2 channels, which are **unavailable while Wi-Fi is active** (readings may be 0).
+
 ## System Status Tool Documentation
 
 ### Complete Parameter Reference
@@ -390,7 +413,7 @@ if (millis() - last_request < MIN_REQUEST_INTERVAL) {
 ### Version 1.0.0 (Current)
 
 - Complete MCP protocol implementation
-- Five core tools (LED, flash, capture, WiFi status, system status)
+- Six core tools (LED, flash, capture, GPIO, WiFi status, system status)
 - Robust WiFi management with auto-reconnection
 - Comprehensive error handling and reporting
 - Base64 image encoding and transfer (optimized for 4KB limit)

--- a/PROJECT_DOCS.md
+++ b/PROJECT_DOCS.md
@@ -31,7 +31,7 @@ The ESP32-CAM MCP Server is a comprehensive IoT solution that transforms an ESP3
 
 - **Hardware**: ESP32-CAM with OV2640 camera sensor
 - **Framework**: Arduino/ESP-IDF via PlatformIO
-- **Protocol**: Model Context Protocol (MCP) 2024-11-05
+- **Protocol**: Model Context Protocol (MCP) 2025-06-18
 - **Networking**: WiFi with HTTP server
 - **Data Format**: JSON-RPC 2.0 with base64 image encoding (under 4KB)
 
@@ -75,7 +75,7 @@ void handle_capture_tool(const JsonObject& arguments, JsonDocument& response);
 
 ### MCP Protocol Implementation
 
-The server implements a complete MCP 2024-11-05 protocol stack:
+The server implements a complete MCP 2025-06-18 protocol stack:
 
 #### Core Methods
 

--- a/PROJECT_DOCS.md
+++ b/PROJECT_DOCS.md
@@ -180,12 +180,12 @@ The `gpio` tool controls the GPIO pins of the ESP32-CAM. Valid pins are **GPIO2,
 - **`di`** (digital input) — Configures the pin as a digital input. Returns `value` as `true`/`false` depending on the logical level of the pin.
 - **`ai`** (analog input) — Configures the pin as an analog input. Uses the ADC calibration helper functions (`analogReadMilliVolts`) for a linear reading, and returns `value` as the percentage (0-100) of the max input (3.3V).
 - **`do`** (digital output) — Configures the pin as a digital output. Accepts `value` `true`/`false` and sets the pin to the corresponding logical level.
-- **`ao`** (analog output) — Configures the pin as a PWM (analog) output. Accepts `value` `0-100` as the duty cycle percentage.
+- **`ao`** (analog output) — Configures the pin as a PWM (analog) output. Accepts `value` `0-100` as the duty cycle percentage; **floats are accepted for sub-1% duty** (e.g. `0.5` = 0.5%).
 
 #### Implementation Details
 
 - Each pin is mapped to a dedicated LEDC channel (10-15) for analog output, using high-speed group 1 (timers 1-3). These never collide with the camera's XCLK PWM, which uses low-speed group 0 (timer 0 or 1, channel 0 or 1).
-- Analog output uses 5000 Hz with 8-bit resolution (duty 0-255), set from the requested percentage.
+- Analog output uses 5000 Hz with 13-bit resolution (duty 0-8191), set from the requested percentage. Duty is computed as a float so sub-1% values are usable (e.g. 0.1% ≈ 8 steps).
 - Analog input expresses the calibrated millivolt reading as a percentage of the 3300 mV reference.
 
 #### Known Limitations

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -55,7 +55,7 @@ pio device monitor
 ### GPIO Control
 
 - **Function**: Read/write GPIO pins
-- **Parameters**: `pin` (2, 12, 13, 14, 15), `mode` (`di`, `ai`, `do`, `ao`), `value` (bool for `do`, 0-100 for `ao`)
+- **Parameters**: `pin` (2, 12, 13, 14, 15), `mode` (`di`, `ai`, `do`, `ao`), `value` (bool for `do`, 0-100 float for `ao`, sub-1% supported)
 - **Modes**:
   - `di` — digital input, returns `value` `true`/`false`
   - `ai` — analog input, returns `value` 0-100 (calibrated % of max input)

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -44,7 +44,7 @@ pio device monitor
 ### LED Control
 
 - **Function**: Control built-in LED
-- **Parameters**: `state` ("on" or "off")
+- **Parameters**: `on` (true or false)
 
 ### Flash Control  
 
@@ -54,7 +54,7 @@ pio device monitor
 ### Image Capture
 
 - **Function**: Capture JPEG image
-- **Parameters**: `flash` ("on" or "off", optional)
+- **Parameters**: `flash` (true or false, optional), `frame_size`, `quality`, `whitebalance`, `pixelformat`
 - **Output**: Base64-encoded JPEG image data
 - **Important**: Images are automatically resized to stay below 4KB base64 encoding limit due to AI client data constraints
 
@@ -76,7 +76,7 @@ The server accepts HTTP POST requests with JSON-RPC 2.0 format on port 80.
 
 ```json
 {
-  "jsonrpc": "2024-11-05",
+  "jsonrpc": "2.0",
   "id": 1,
   "method": "tools/call",
   "params": {
@@ -92,12 +92,12 @@ The server accepts HTTP POST requests with JSON-RPC 2.0 format on port 80.
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 1,
     "method": "tools/call",
     "params": {
       "name": "capture",
-      "arguments": {"flash": "on"}
+      "arguments": {"flash": true}
     }
   }'
 ```
@@ -108,12 +108,12 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 1,
     "method": "tools/call",
     "params": {
       "name": "led",
-      "arguments": {"state": "on"}
+      "arguments": {"on": true}
     }
   }'
 ```
@@ -128,12 +128,12 @@ import base64
 
 def capture_image(esp32_ip):
     payload = {
-        "jsonrpc": "2024-11-05",
+        "jsonrpc": "2.0",
         "id": 1,
         "method": "tools/call",
         "params": {
             "name": "capture",
-            "arguments": {"flash": "on"}
+            "arguments": {"flash": true}
         }
     }
     
@@ -152,12 +152,12 @@ def capture_image(esp32_ip):
 
 ```powershell
 $payload = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 1
     method = "tools/call"
     params = @{
         name = "capture"
-        arguments = @{flash = "on"}
+        arguments = @{flash = $true}
     }
 } | ConvertTo-Json -Depth 10
 
@@ -174,7 +174,7 @@ Invoke-RestMethod -Uri "http://192.168.1.100/" -Method Post -Body $payload -Cont
 
 ## Technical Specifications
 
-- **Protocol**: Model Context Protocol 2024-11-05
+- **Protocol**: Model Context Protocol 2025-06-18
 - **Network**: HTTP server on port 80
 - **Image Format**: JPEG with base64 encoding
 - **Image Size Limit**: Under 4KB encoded (due to AI client limitations)

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -10,6 +10,7 @@ This project transforms an ESP32-CAM module into a remotely controllable camera 
 
 - **Remote Camera Control**: Capture images with optional flash
 - **LED Management**: Control built-in LED state
+- **GPIO Control**: Read/write GPIO pins (digital/analog in/out) via the `gpio` tool
 - **System Monitoring**: WiFi status and hardware diagnostics
 - **MCP Protocol Compliance**: Standard JSON-RPC 2.0 interface
 - **Network Reliability**: Auto-reconnection and watchdog protection
@@ -50,6 +51,17 @@ pio device monitor
 
 - **Function**: Trigger camera flash
 - **Parameters**: `duration` (5-100ms, default 50ms)
+
+### GPIO Control
+
+- **Function**: Read/write GPIO pins
+- **Parameters**: `pin` (2, 12, 13, 14, 15), `mode` (`di`, `ai`, `do`, `ao`), `value` (bool for `do`, 0-100 for `ao`)
+- **Modes**:
+  - `di` — digital input, returns `value` `true`/`false`
+  - `ai` — analog input, returns `value` 0-100 (calibrated % of max input)
+  - `do` — digital output, sets `value` `true`/`false`
+  - `ao` — analog output (PWM), sets `value` 0-100 duty cycle
+- **Output**: Pin state/value and status text
 
 ### Image Capture
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -43,6 +43,7 @@ WIFI_PASSWORD="YourPassword"
 | `led` | `on`: true/false | Control built-in LED |
 | `flash` | `duration`: 5-100ms | Trigger camera flash |
 | `capture` | `flash`: true/false, `frame_size`, `quality`, `whitebalance`, `pixelformat` | Take photo with optional flash |
+| `gpio` | `pin`: 2,12,13,14,15; `mode`: di/ai/do/ao; `value`: bool or 0-100 | Read/write GPIO pins |
 | `wifi_status` | None | Get network information |
 | `system_status` | None | Get system diagnostics |
 
@@ -142,10 +143,27 @@ $ledOn = @{
 
 Invoke-RestMethod -Uri "http://192.168.1.100/" -Method Post -Body $ledOn -ContentType "application/json"
 
+# Set GPIO2 as digital output HIGH
+$gpio = @{
+    jsonrpc = "2.0"
+    id = 4
+    method = "tools/call"
+    params = @{
+        name = "gpio"
+        arguments = @{
+            pin = 2
+            mode = "do"
+            value = $true
+        }
+    }
+} | ConvertTo-Json -Depth 10
+
+Invoke-RestMethod -Uri "http://192.168.1.100/" -Method Post -Body $gpio -ContentType "application/json"
+
 # Capture image with flash
 $capture = @{
     jsonrpc = "2.0"
-    id = 4
+    id = 5
     method = "tools/call"
     params = @{
         name = "capture"
@@ -264,6 +282,23 @@ curl -X POST http://192.168.1.100/ \
       "arguments": {}
     }
   }'
+
+# Set GPIO2 as digital output HIGH
+curl -X POST http://192.168.1.100/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 8,
+    "method": "tools/call",
+    "params": {
+      "name": "gpio",
+      "arguments": {
+        "pin": 2,
+        "mode": "do",
+        "value": true
+      }
+    }
+  }'
 ```
 
 ## Python Integration Example
@@ -348,6 +383,15 @@ class ESP32CamClient:
             "name": "system_status",
             "arguments": {}
         })
+    
+    def gpio(self, pin, mode, value=None):
+        arguments = {"pin": pin, "mode": mode}
+        if value is not None:
+            arguments["value"] = value
+        return self._make_request("tools/call", {
+            "name": "gpio",
+            "arguments": arguments
+        })
 
 # Usage example
 if __name__ == "__main__":
@@ -372,6 +416,15 @@ if __name__ == "__main__":
     # Flash the camera
     print("Flashing camera...")
     cam.flash_control(75)
+    
+    # Set GPIO2 as digital output HIGH
+    print("\nSetting GPIO2 HIGH...")
+    cam.gpio(2, "do", True)
+    
+    # Read GPIO13 as digital input
+    print("Reading GPIO13...")
+    gpio_result = cam.gpio(13, "di")
+    print(f"GPIO13 value: {gpio_result.get('result', {}).get('structuredContent', {}).get('value')}")
     
     # Capture image
     print("Capturing image...")
@@ -664,7 +717,7 @@ Create `.vscode/esp32cam.code-snippets`:
       "  \"id\": ${1:1},",
       "  \"method\": \"tools/call\",",
       "  \"params\": {",
-      "    \"name\": \"${2|led,flash,capture,wifi_status,system_status|}\",",
+      "    \"name\": \"${2|led,flash,capture,gpio,wifi_status,system_status|}\",",
       "    \"arguments\": {",
       "      $3",
       "    }",

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -40,9 +40,9 @@ WIFI_PASSWORD="YourPassword"
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `led` | `state`: "on"/"off" | Control built-in LED |
+| `led` | `on`: true/false | Control built-in LED |
 | `flash` | `duration`: 5-100ms | Trigger camera flash |
-| `capture` | `flash`: "on"/"off" | Take photo with optional flash |
+| `capture` | `flash`: true/false, `frame_size`, `quality`, `whitebalance`, `pixelformat` | Take photo with optional flash |
 | `wifi_status` | None | Get network information |
 | `system_status` | None | Get system diagnostics |
 
@@ -103,11 +103,11 @@ The `system_status` tool returns comprehensive diagnostic information about the 
 ```powershell
 # Initialize MCP connection
 $init = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 1
     method = "initialize"
     params = @{
-        protocolVersion = "2024-11-05"
+        protocolVersion = "2025-06-18"
         capabilities = @{}
         clientInfo = @{
             name = "PowerShell Client"
@@ -120,7 +120,7 @@ Invoke-RestMethod -Uri "http://192.168.1.100/" -Method Post -Body $init -Content
 
 # List available tools
 $listTools = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 2
     method = "tools/list"
 } | ConvertTo-Json
@@ -129,13 +129,13 @@ Invoke-RestMethod -Uri "http://192.168.1.100/" -Method Post -Body $listTools -Co
 
 # Turn on LED
 $ledOn = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 3
     method = "tools/call"
     params = @{
         name = "led"
         arguments = @{
-            state = "on"
+            on = $true
         }
     }
 } | ConvertTo-Json -Depth 10
@@ -144,13 +144,13 @@ Invoke-RestMethod -Uri "http://192.168.1.100/" -Method Post -Body $ledOn -Conten
 
 # Capture image with flash
 $capture = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 4
     method = "tools/call"
     params = @{
         name = "capture"
         arguments = @{
-            flash = "on"
+            flash = $true
         }
     }
 } | ConvertTo-Json -Depth 10
@@ -172,11 +172,11 @@ if ($response.result.content[1].type -eq "image") {
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 1,
     "method": "initialize",
     "params": {
-      "protocolVersion": "2024-11-05",
+      "protocolVersion": "2025-06-18",
       "capabilities": {},
       "clientInfo": {
         "name": "curl Client",
@@ -189,7 +189,7 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 2,
     "method": "tools/list"
   }'
@@ -198,13 +198,13 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 3,
     "method": "tools/call",
     "params": {
       "name": "led",
       "arguments": {
-        "state": "on"
+        "on": true
       }
     }
   }'
@@ -213,7 +213,7 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 4,
     "method": "tools/call",
     "params": {
@@ -228,13 +228,13 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 5,
     "method": "tools/call",
     "params": {
       "name": "capture",
       "arguments": {
-        "flash": "on"
+        "flash": true
       }
     }
   }'
@@ -243,7 +243,7 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 6,
     "method": "tools/call",
     "params": {
@@ -256,7 +256,7 @@ curl -X POST http://192.168.1.100/ \
 curl -X POST http://192.168.1.100/ \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 7,
     "method": "tools/call",
     "params": {
@@ -281,7 +281,7 @@ class ESP32CamClient:
     
     def _make_request(self, method, params=None):
         payload = {
-            "jsonrpc": "2024-11-05",
+            "jsonrpc": "2.0",
             "id": self.request_id,
             "method": method
         }
@@ -294,7 +294,7 @@ class ESP32CamClient:
     
     def initialize(self):
         return self._make_request("initialize", {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": "2025-06-18",
             "capabilities": {},
             "clientInfo": {
                 "name": "Python Client",
@@ -320,7 +320,7 @@ class ESP32CamClient:
     def capture_image(self, use_flash=False, save_path=None):
         result = self._make_request("tools/call", {
             "name": "capture",
-            "arguments": {"flash": "on" if use_flash else "off"}
+            "arguments": {"flash": True if use_flash else False}
         })
         
         if "result" in result and len(result["result"]["content"]) > 1:
@@ -492,12 +492,12 @@ rest_command:
       Content-Type: "application/json"
     payload: |
       {
-        "jsonrpc": "2024-11-05",
+        "jsonrpc": "2.0",
         "id": 1,
         "method": "tools/call",
         "params": {
           "name": "capture",
-          "arguments": {"flash": "on"}
+          "arguments": {"flash": true}
         }
       }
 ```
@@ -599,7 +599,7 @@ Create `.vscode/tasks.json` for common operations:
         "-X", "POST",
         "http://192.168.1.100/",
         "-H", "Content-Type: application/json",
-        "-d", "{\"jsonrpc\":\"2024-11-05\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"capture\",\"arguments\":{\"flash\":\"on\"}}}"
+        "-d", "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"capture\",\"arguments\":{\"flash\":true}}}"
       ],
       "group": "build",
       "presentation": {
@@ -618,7 +618,7 @@ Create `.vscode/tasks.json` for common operations:
         "-X", "POST",
         "http://192.168.1.100/",
         "-H", "Content-Type: application/json",
-        "-d", "{\"jsonrpc\":\"2024-11-05\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"led\",\"arguments\":{\"state\":\"on\"}}}"
+        "-d", "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"led\",\"arguments\":{\"on\":true}}}"
       ],
       "group": "build"
     },
@@ -630,7 +630,7 @@ Create `.vscode/tasks.json` for common operations:
         "-X", "POST",
         "http://192.168.1.100/",
         "-H", "Content-Type: application/json",
-        "-d", "{\"jsonrpc\":\"2024-11-05\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"led\",\"arguments\":{\"state\":\"off\"}}}"
+        "-d", "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"led\",\"arguments\":{\"state\":\"off\"}}}"
       ],
       "group": "build"
     },
@@ -642,7 +642,7 @@ Create `.vscode/tasks.json` for common operations:
         "-X", "POST", 
         "http://192.168.1.100/",
         "-H", "Content-Type: application/json",
-        "-d", "{\"jsonrpc\":\"2024-11-05\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"system_status\",\"arguments\":{}}}"
+        "-d", "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"system_status\",\"arguments\":{}}}"
       ],
       "group": "test"
     }
@@ -660,7 +660,7 @@ Create `.vscode/esp32cam.code-snippets`:
     "prefix": "esp32-mcp",
     "body": [
       "{",
-      "  \"jsonrpc\": \"2024-11-05\",",
+      "  \"jsonrpc\": \"2.0\",",
       "  \"id\": ${1:1},",
       "  \"method\": \"tools/call\",",
       "  \"params\": {",
@@ -677,13 +677,13 @@ Create `.vscode/esp32cam.code-snippets`:
     "prefix": "esp32-led",
     "body": [
       "{",
-      "  \"jsonrpc\": \"2024-11-05\",",
+      "  \"jsonrpc\": \"2.0\",",
       "  \"id\": ${1:1},",
       "  \"method\": \"tools/call\",",
       "  \"params\": {",
       "    \"name\": \"led\",",
       "    \"arguments\": {",
-      "      \"state\": \"${2|on,off|}\"",
+      "      \"on\": ${2|true,false|}",
       "    }",
       "  }",
       "}"
@@ -694,13 +694,13 @@ Create `.vscode/esp32cam.code-snippets`:
     "prefix": "esp32-capture",
     "body": [
       "{",
-      "  \"jsonrpc\": \"2024-11-05\",",
+      "  \"jsonrpc\": \"2.0\",",
       "  \"id\": ${1:1},",
       "  \"method\": \"tools/call\",",
       "  \"params\": {",
       "    \"name\": \"capture\",",
       "    \"arguments\": {",
-      "      \"flash\": \"${2|on,off|}\"",
+      "      \"flash\": ${2|true,false|}",
       "    }",
       "  }",
       "}"
@@ -722,11 +722,11 @@ POST http://192.168.1.100/
 Content-Type: application/json
 
 {
-  "jsonrpc": "2024-11-05",
+  "jsonrpc": "2.0",
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-06-18",
     "capabilities": {},
     "clientInfo": {
       "name": "VS Code REST Client",
@@ -740,7 +740,7 @@ POST http://192.168.1.100/
 Content-Type: application/json
 
 {
-  "jsonrpc": "2024-11-05",
+  "jsonrpc": "2.0",
   "id": 2,
   "method": "tools/list"
 }
@@ -750,13 +750,13 @@ POST http://192.168.1.100/
 Content-Type: application/json
 
 {
-  "jsonrpc": "2024-11-05",
+  "jsonrpc": "2.0",
   "id": 3,
   "method": "tools/call",
   "params": {
     "name": "led",
     "arguments": {
-      "state": "on"
+      "on": true
     }
   }
 }
@@ -766,13 +766,13 @@ POST http://192.168.1.100/
 Content-Type: application/json
 
 {
-  "jsonrpc": "2024-11-05",
+  "jsonrpc": "2.0",
   "id": 4,
   "method": "tools/call",
   "params": {
     "name": "capture",
     "arguments": {
-      "flash": "on"
+      "flash": true
     }
   }
 }
@@ -782,7 +782,7 @@ POST http://192.168.1.100/
 Content-Type: application/json
 
 {
-  "jsonrpc": "2024-11-05",
+  "jsonrpc": "2.0",
   "id": 5,
   "method": "tools/call",
   "params": {

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -43,7 +43,7 @@ WIFI_PASSWORD="YourPassword"
 | `led` | `on`: true/false | Control built-in LED |
 | `flash` | `duration`: 5-100ms | Trigger camera flash |
 | `capture` | `flash`: true/false, `frame_size`, `quality`, `whitebalance`, `pixelformat` | Take photo with optional flash |
-| `gpio` | `pin`: 2,12,13,14,15; `mode`: di/ai/do/ao; `value`: bool or 0-100 | Read/write GPIO pins |
+| `gpio` | `pin`: 2,12,13,14,15; `mode`: di/ai/do/ao; `value`: bool or 0-100 (float, sub-1% ok) | Read/write GPIO pins |
 | `wifi_status` | None | Get network information |
 | `system_status` | None | Get system diagnostics |
 
@@ -299,6 +299,23 @@ curl -X POST http://192.168.1.100/ \
       }
     }
   }'
+
+# Set GPIO4 to 0.5% PWM duty (analog output; float accepted for sub-1%)
+curl -X POST http://192.168.1.100/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 9,
+    "method": "tools/call",
+    "params": {
+      "name": "gpio",
+      "arguments": {
+        "pin": 4,
+        "mode": "ao",
+        "value": 0.5
+      }
+    }
+  }'
 ```
 
 ## Python Integration Example
@@ -420,6 +437,10 @@ if __name__ == "__main__":
     # Set GPIO2 as digital output HIGH
     print("\nSetting GPIO2 HIGH...")
     cam.gpio(2, "do", True)
+    
+    # Set GPIO4 to 0.5% PWM duty (analog output; float accepted for sub-1%)
+    print("\nSetting GPIO4 to 0.5% duty...")
+    cam.gpio(4, "ao", 0.5)
     
     # Read GPIO13 as digital input
     print("Reading GPIO13...")

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Platform: ESP32-CAM](https://img.shields.io/badge/Platform-ESP32--CAM-blue)](https://www.espressif.com/)
 [![Framework: Arduino](https://img.shields.io/badge/Framework-Arduino-00979D)](https://www.arduino.cc/)
 [![Language: C++](https://img.shields.io/badge/Language-C%2B%2B-00599C)](https://isocpp.org/)
-[![MCP: 2024-11-05](https://img.shields.io/badge/MCP-2024--11--05-blueviolet)](https://modelcontextprotocol.io/)
+[![MCP: 2025-06-18](https://img.shields.io/badge/MCP-2025--06--18-blueviolet)](https://modelcontextprotocol.io/)
 [![Release](https://img.shields.io/github/v/release/rzeldent/esp32-cam-ai)](https://github.com/rzeldent/esp32-cam-ai/releases)
 
 [<img src="assets/images/esp32-cam-ai.png" alt="ESP32-CAM-AI" width="320">](assets/images/esp32-cam-ai.png)
@@ -43,7 +43,7 @@ Brief: **Use Copilot or other AI digital assistants, like AI-Toolkit (in VSCode)
 
 ### MCP Protocol Support
 
-- **Standard Compliance**: Full MCP 2024-11-05 protocol implementation
+- **Standard Compliance**: Full MCP 2025-06-18 protocol implementation
 - **Tool Schema**: Proper JSON schema validation for all tools
 - **Error Handling**: Comprehensive error reporting with proper codes
 - **Notifications**: Support for `notifications/initialized`
@@ -182,7 +182,7 @@ Controls the ESP32-CAM's built-in LED state.
 
 **Parameters:**
 
-- `state` (required): `"on"` or `"off"`
+- `on` (required): `true` or `false`
 
 **Example:**
 
@@ -192,7 +192,7 @@ Controls the ESP32-CAM's built-in LED state.
   "method": "tools/call",
   "params": {
     "name": "led",
-    "arguments": {"state": "on"}
+    "arguments": {"on": true}
   }
 }
 ```
@@ -224,7 +224,11 @@ Captures a photo from the ESP32-CAM sensor.
 
 **Parameters:**
 
-- `flash` (optional): `"on"` or `"off"` - Use flash during capture
+- `flash` (optional): `true` or `false` - Use flash during capture
+- `frame_size` (optional): Resolution, e.g. `VGA (640x480)`
+- `quality` (optional): JPEG quality 1-100 (default: 20)
+- `whitebalance` (optional): `Auto`, `Sunny`, `Cloudy`, `Office`, or `Home`
+- `pixelformat` (optional): e.g. `JPEG`, `RGB565`, `Grayscale`
 
 **Response:**
 
@@ -240,7 +244,7 @@ Captures a photo from the ESP32-CAM sensor.
   "method": "tools/call",
   "params": {
     "name": "capture",
-    "arguments": {"flash": "on"}
+    "arguments": {"flash": true}
   }
 }
 ```
@@ -306,7 +310,7 @@ Provides comprehensive system diagnostics and health monitoring.
 
 ```powershell
 # Capture image with flash
-$body = '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "capture", "arguments": {"flash": "on"}}}'
+$body = '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "capture", "arguments": {"flash": true}}}'
 Invoke-RestMethod -Uri "http://192.168.1.132/" -Method Post -Body $body -ContentType "application/json"
 ```
 
@@ -537,7 +541,7 @@ def capture_image(esp32_ip, use_flash=False):
         "method": "tools/call",
         "params": {
             "name": "capture",
-            "arguments": {"flash": "on" if use_flash else "off"}
+            "arguments": {"flash": True if use_flash else False}
         }
     }
     
@@ -573,7 +577,7 @@ async function captureImage(esp32IP, useFlash = false) {
         method: "tools/call",
         params: {
             name: "capture",
-            arguments: { flash: useFlash ? "on" : "off" }
+            arguments: { flash: useFlash }
         }
     };
     

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Controls the GPIO pins of the ESP32-CAM. Valid pins: **2, 12, 13, 14, 15**.
   - `di` (digital input) — returns `value` `true`/`false` from the pin's logical level
   - `ai` (analog input) — returns `value` `0-100` (percentage of the calibrated max input, via `analogReadMilliVolts`)
   - `do` (digital output) — sets `value` `true`/`false` on the pin (logical level)
-  - `ao` (analog output) — sets `value` `0-100` (PWM duty cycle percentage)
-- `value` (required for output modes): boolean for `do`, `0-100` number for `ao`
+  - `ao` (analog output) — sets `value` `0-100` (PWM duty cycle percentage; float accepted for sub-1% duty, e.g. `0.5` = 0.5%)
+- `value` (required for output modes): boolean for `do`, `0-100` number (float allowed) for `ao`
 
 **Notes:**
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Brief: **Use Copilot or other AI digital assistants, like AI-Toolkit (in VSCode)
 - **LED Control**: Turn the ESP32-CAM's built-in LED on/off
 - **Flash Control**: Trigger camera flash with configurable duration (5-100ms)
 - **Camera Capture**: Take photos with optional flash support (optimized for <4KB base64)
+- **GPIO Control**: Read/write GPIO pins (digital/analog in/out) via the `gpio` tool
 - **Real-time Control**: Instant response to MCP tool calls
 
 ### System Monitoring
@@ -214,6 +215,48 @@ Triggers the camera flash for a specified duration.
   "params": {
     "name": "flash",
     "arguments": {"duration": 75}
+  }
+}
+```
+
+### GPIO Control
+
+Controls the GPIO pins of the ESP32-CAM. Valid pins: **2, 12, 13, 14, 15**.
+
+**Parameters:**
+
+- `pin` (required): GPIO pin number. Valid pins: `2`, `12`, `13`, `14`, `15`
+- `mode` (required): One of:
+  - `di` (digital input) — returns `value` `true`/`false` from the pin's logical level
+  - `ai` (analog input) — returns `value` `0-100` (percentage of the calibrated max input, via `analogReadMilliVolts`)
+  - `do` (digital output) — sets `value` `true`/`false` on the pin (logical level)
+  - `ao` (analog output) — sets `value` `0-100` (PWM duty cycle percentage)
+- `value` (required for output modes): boolean for `do`, `0-100` number for `ao`
+
+**Notes:**
+
+- Analog input pins are ADC2 channels, which are unavailable while Wi-Fi is active (readings may be 0).
+
+**Examples:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "gpio",
+    "arguments": {"pin": 2, "mode": "do", "value": true}
+  }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "gpio",
+    "arguments": {"pin": 13, "mode": "ao", "value": 75}
   }
 }
 ```
@@ -560,8 +603,38 @@ def capture_image(esp32_ip, use_flash=False):
     else:
         print(f"Error: {data.get('error', {}).get('message', 'Unknown error')}")
 
+def gpio_control(esp32_ip, pin, mode, value=None):
+    url = f"http://{esp32_ip}/"
+    arguments = {"pin": pin, "mode": mode}
+    if value is not None:
+        arguments["value"] = value
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "gpio",
+            "arguments": arguments
+        }
+    }
+
+    response = requests.post(url, json=payload)
+    data = response.json()
+
+    if "result" in data:
+        sc = data["result"].get("structuredContent", {})
+        print(f"GPIO{pin} ({mode}) value: {sc.get('value')}")
+        return sc
+    else:
+        print(f"Error: {data.get('error', {}).get('message', 'Unknown error')}")
+        return None
+
 # Usage
 capture_image("192.168.1.132", use_flash=True)
+gpio_control("192.168.1.132", 2, "do", True)   # GPIO2 -> HIGH
+gpio_control("192.168.1.132", 13, "ao", 75)    # GPIO13 -> 75% PWM
+gpio_control("192.168.1.132", 13, "di")        # Read GPIO13
 ```
 
 #### Node.js Integration

--- a/browser_controller.html
+++ b/browser_controller.html
@@ -15,11 +15,14 @@
         .error { color: red; background: #ffe6e6; border-left: 4px solid red; }
         .success { color: green; background: #e6ffe6; border-left: 4px solid green; }
         .response { font-family: monospace; background: #f8f8f8; padding: 10px; margin: 10px 0; border-radius: 5px; max-height: 300px; overflow-y: auto; border: 1px solid #ddd; }
+        .text-return { font-family: monospace; background: #f8f8f8; padding: 10px; margin: 10px 0; border-radius: 5px; border: 1px solid #ddd; white-space: pre-wrap; }
         .hidden { display: none; }
         .visible { display: block; }
         .url-input { width: 300px; padding: 8px; margin: 5px; border: 1px solid #ddd; border-radius: 4px; }
         .control-group { margin: 15px 0; padding: 15px; background: #f8f9fa; border-radius: 4px; }
         .control-group h3 { margin-top: 0; color: #333; }
+        .control-group label { margin-left: 10px; }
+        .control-group select, .control-group input[type="number"] { padding: 6px; margin: 5px; border: 1px solid #ddd; border-radius: 4px; }
     </style>
 </head>
 <body>
@@ -50,9 +53,20 @@
             <h3>Camera Controls</h3>
             <button onclick="ledOn()">LED On</button>
             <button onclick="ledOff()">LED Off</button>
-            <button onclick="flashCamera()">Flash Camera</button>
-            <button onclick="captureImage('off')">Capture Image (No Flash)</button>
-            <button onclick="captureImage('on')">Capture Image (With Flash)</button>
+            <button onclick="flash()">Flash</button>
+            <button onclick="captureImage()">Capture Image</button>
+            <button onclick="loadToolOptions()">Reload Options</button>
+            <br><br>
+            <label for="capture-flash">Flash:</label>
+            <input type="checkbox" id="capture-flash">
+            <label for="capture-frame-size">Frame Size:</label>
+            <select id="capture-frame-size"></select>
+            <label for="capture-quality">Quality:</label>
+            <input type="number" id="capture-quality" min="1" max="100" value="20">
+            <label for="capture-whitebalance">White Balance:</label>
+            <select id="capture-whitebalance"></select>
+            <label for="capture-pixelformat">Pixel Format:</label>
+            <select id="capture-pixelformat"></select>
         </div>
 
         <div id="status" class="status">Ready to connect...</div>
@@ -63,6 +77,11 @@
         </div>
         
         <div id="response" class="response hidden"></div>
+        
+        <div class="control-group">
+            <h3>Text</h3>
+            <div id="text-return" class="text-return hidden"></div>
+        </div>
         
         <div id="image-container" class="image-container hidden">
             <h3>Captured Image:</h3>
@@ -106,12 +125,37 @@
             const responseDiv = document.getElementById('response');
             responseDiv.textContent = JSON.stringify(response, null, 2);
             responseDiv.className = 'response visible';
+            showTextReturn(response);
+        }
+
+        // Displays the "text" content items of the response in the Text Return panel.
+        function showTextReturn(response) {
+            const el = document.getElementById('text-return');
+            let text = '';
+            if (response && response.result && response.result.content) {
+                for (const item of response.result.content) {
+                    if (item.type === 'text') {
+                        if (text) text += '\n';
+                        text += item.text;
+                    }
+                }
+            }
+            if (text) {
+                el.textContent = text;
+                el.className = 'text-return visible';
+            } else {
+                el.textContent = '';
+                el.className = 'text-return hidden';
+            }
         }
 
         function clearResponse() {
             const responseDiv = document.getElementById('response');
             responseDiv.textContent = '';
             responseDiv.className = 'response hidden';
+            const textReturn = document.getElementById('text-return');
+            textReturn.textContent = '';
+            textReturn.className = 'text-return hidden';
             updateStatus('Response cleared');
         }
 
@@ -147,7 +191,7 @@
             }
             
             const payload = {
-                jsonrpc: "2024-11-05",
+                jsonrpc: "2.0",
                 id: requestId++,
                 method: method
             };
@@ -194,7 +238,7 @@
 
         async function initialize() {
             const result = await sendMCPRequest('initialize', {
-                protocolVersion: "2024-11-05",
+                protocolVersion: "2025-06-18",
                 capabilities: {},
                 clientInfo: {
                     name: "Browser MCP Client",
@@ -211,13 +255,57 @@
             const result = await sendMCPRequest('tools/list');
             if (result) {
                 updateStatus(`Found ${result.tools?.length || 0} available tools`);
+                populateCaptureOptions(result);
+            }
+        }
+
+        // Populates the capture dropdowns from the enums advertised by tools/list,
+        // and applies the advertised defaults to the non-enum controls.
+        function populateCaptureOptions(result) {
+            const capture = result && result.tools ? result.tools.find(t => t.name === 'capture') : null;
+            if (!capture || !capture.inputSchema || !capture.inputSchema.properties) {
+                updateStatus('Capture tool not found in tools/list', true);
+                return false;
+            }
+            const props = capture.inputSchema.properties;
+            const fillEnum = (selectId, prop) => {
+                if (!prop || !Array.isArray(prop.enum)) return;
+                const select = document.getElementById(selectId);
+                select.innerHTML = '';
+                for (const value of prop.enum) {
+                    const option = document.createElement('option');
+                    option.value = value;
+                    option.textContent = value;
+                    if (value === prop.default) {
+                        option.selected = true;
+                    }
+                    select.appendChild(option);
+                }
+            };
+            fillEnum('capture-frame-size', props.frame_size);
+            fillEnum('capture-whitebalance', props.whitebalance);
+            fillEnum('capture-pixelformat', props.pixelformat);
+
+            if (props.quality && props.quality.default != null) {
+                document.getElementById('capture-quality').value = props.quality.default;
+            }
+            if (props.flash && props.flash.default != null) {
+                document.getElementById('capture-flash').checked = !!props.flash.default;
+            }
+            return true;
+        }
+
+        async function loadToolOptions() {
+            const result = await sendMCPRequest('tools/list');
+            if (result && populateCaptureOptions(result)) {
+                updateStatus('Capture options loaded from tools/list');
             }
         }
 
         async function ledOn() {
             const result = await sendMCPRequest('tools/call', {
                 name: 'led',
-                arguments: { state: 'on' }
+                arguments: { on: true }
             });
             if (result) {
                 updateStatus('LED turned on');
@@ -227,14 +315,14 @@
         async function ledOff() {
             const result = await sendMCPRequest('tools/call', {
                 name: 'led',
-                arguments: { state: 'off' }
+                arguments: { on: false }
             });
             if (result) {
                 updateStatus('LED turned off');
             }
         }
 
-        async function flashCamera() {
+        async function flash() {
             const result = await sendMCPRequest('tools/call', {
                 name: 'flash',
                 arguments: {}
@@ -258,33 +346,61 @@
             });
         }
 
-        async function captureImage(flash = 'off') {
+        async function captureImage() {
+            // Clear any previously displayed image before the new capture
+            clearCapturedImage();
+
+            const quality = parseInt(document.getElementById('capture-quality').value, 10);
             const result = await sendMCPRequest('tools/call', {
                 name: 'capture',
-                arguments: { flash: flash }
+                arguments: {
+                    flash: document.getElementById('capture-flash').checked,
+                    frame_size: document.getElementById('capture-frame-size').value,
+                    quality: isNaN(quality) ? 20 : quality,
+                    whitebalance: document.getElementById('capture-whitebalance').value,
+                    pixelformat: document.getElementById('capture-pixelformat').value
+                }
             });
 
-            if (result && result.content && result.content.length > 0) {
-                // Look for the image content in the response
+            if (result && (result.content || result.structuredContent)) {
+                // Look for the image in the content array (legacy) or in structuredContent
                 let imageContent = null;
                 let textContent = null;
                 
-                for (let i = 0; i < result.content.length; i++) {
-                    const content = result.content[i];
-                    if (content.type === 'image') {
-                        imageContent = content;
-                    } else if (content.type === 'text') {
-                        textContent = content;
+                if (result.content) {
+                    for (let i = 0; i < result.content.length; i++) {
+                        const content = result.content[i];
+                        if (content.type === 'image') {
+                            imageContent = content;
+                        } else if (content.type === 'text') {
+                            textContent = content;
+                        }
                     }
+                }
+                
+                // The server returns the image inside structuredContent
+                if (!imageContent && result.structuredContent && result.structuredContent.image) {
+                    imageContent = {
+                        data: result.structuredContent.image,
+                        format: result.structuredContent.format,
+                        width: result.structuredContent.width,
+                        height: result.structuredContent.height,
+                        mimeType: result.structuredContent.mimeType
+                    };
                 }
                 
                 if (imageContent && imageContent.data) {
                     const img = document.getElementById('captured-image');
-                    img.src = `data:${imageContent.mimeType || 'image/jpeg'};base64,${imageContent.data}`;
-                    document.getElementById('image-container').className = 'image-container visible';
-                    
-                    const statusMsg = textContent ? textContent.text : `Image captured (${imageContent.data.length} bytes base64)`;
-                    updateStatus(statusMsg);
+                    const displaySrc = renderCapturedImage(imageContent);
+                    if (displaySrc) {
+                        img.src = displaySrc;
+                        document.getElementById('image-container').className = 'image-container visible';
+                        
+                        const statusMsg = textContent ? textContent.text : `Image captured (${imageContent.data.length} bytes base64)`;
+                        updateStatus(statusMsg);
+                    } else {
+                        updateStatus(`Captured data cannot be displayed in the browser (format: ${imageContent.format || 'unknown'})`, true);
+                    }
                 } else {
                     updateStatus('Image capture succeeded but no image data found in response', true);
                 }
@@ -293,9 +409,112 @@
             }
         }
 
-        // Test CORS support on page load
+        // Clears the previously displayed captured image.
+        function clearCapturedImage() {
+            const img = document.getElementById('captured-image');
+            img.removeAttribute('src');
+            document.getElementById('image-container').className = 'image-container hidden';
+        }
+
+        // Decodes a raw (non-JPEG) capture to an RGBA canvas and returns a PNG data URL.
+        // Returns null for formats that cannot be decoded (e.g. RAW).
+        function decodeRawImage(format, width, height, bytes) {
+            const canvas = document.createElement('canvas');
+            canvas.width = width;
+            canvas.height = height;
+            const ctx = canvas.getContext('2d');
+            const imageData = ctx.createImageData(width, height);
+            const out = imageData.data;
+            let o = 0;
+            switch (format) {
+                case 'Grayscale':
+                    for (let i = 0; i < bytes.length && o < out.length; i++) {
+                        out[o++] = bytes[i]; out[o++] = bytes[i]; out[o++] = bytes[i]; out[o++] = 255;
+                    }
+                    break;
+                case 'RGB565':
+                    for (let i = 0; i + 1 < bytes.length && o < out.length; i += 2) {
+                        const p = bytes[i] | (bytes[i + 1] << 8);
+                        out[o++] = ((p >> 11) & 0x1F) << 3;
+                        out[o++] = ((p >> 5) & 0x3F) << 2;
+                        out[o++] = (p & 0x1F) << 3;
+                        out[o++] = 255;
+                    }
+                    break;
+                case 'RGB888':
+                    for (let i = 0; i + 2 < bytes.length && o < out.length; i += 3) {
+                        out[o++] = bytes[i];
+                        out[o++] = bytes[i + 1];
+                        out[o++] = bytes[i + 2];
+                        out[o++] = 255;
+                    }
+                    break;
+                case 'RGB444':
+                    for (let i = 0; i + 1 < bytes.length && o < out.length; i += 2) {
+                        const p = bytes[i] | (bytes[i + 1] << 8);
+                        out[o++] = ((p >> 8) & 0x0F) << 4;
+                        out[o++] = ((p >> 4) & 0x0F) << 4;
+                        out[o++] = (p & 0x0F) << 4;
+                        out[o++] = 255;
+                    }
+                    break;
+                case 'RGB555':
+                    for (let i = 0; i + 1 < bytes.length && o < out.length; i += 2) {
+                        const p = bytes[i] | (bytes[i + 1] << 8);
+                        out[o++] = ((p >> 10) & 0x1F) << 3;
+                        out[o++] = ((p >> 5) & 0x1F) << 3;
+                        out[o++] = (p & 0x1F) << 3;
+                        out[o++] = 255;
+                    }
+                    break;
+                case 'YUV422':
+                    // YUYV order: Y0 U Y1 V per 4 bytes (2 pixels)
+                    for (let i = 0; i + 3 < bytes.length && o < out.length; i += 4) {
+                        const y0 = bytes[i], u = bytes[i + 1] - 128, y1 = bytes[i + 2], v = bytes[i + 3] - 128;
+                        out[o++] = yuvToR(y0, u, v); out[o++] = yuvToG(y0, u, v); out[o++] = yuvToB(y0, u, v); out[o++] = 255;
+                        out[o++] = yuvToR(y1, u, v); out[o++] = yuvToG(y1, u, v); out[o++] = yuvToB(y1, u, v); out[o++] = 255;
+                    }
+                    break;
+                case 'YUV420':
+                    // Luma plane only (grayscale approximation)
+                    for (let i = 0; i < bytes.length && o < out.length; i++) {
+                        const v = bytes[i];
+                        out[o++] = v; out[o++] = v; out[o++] = v; out[o++] = 255;
+                    }
+                    break;
+                default:
+                    return null; // RAW is sensor-specific and cannot be decoded
+            }
+            ctx.putImageData(imageData, 0, 0);
+            return canvas.toDataURL('image/png');
+        }
+
+        function yuvToR(y, u, v) { return Math.max(0, Math.min(255, Math.round(y + 1.402 * v))); }
+        function yuvToG(y, u, v) { return Math.max(0, Math.min(255, Math.round(y - 0.344 * u - 0.714 * v))); }
+        function yuvToB(y, u, v) { return Math.max(0, Math.min(255, Math.round(y + 1.772 * u))); }
+
+        // Returns a displayable data URL for a capture content item, or null if unsupported.
+        function renderCapturedImage(imageContent) {
+            const base64 = imageContent.data;
+            // JPEG (or legacy responses without a format field) can be shown directly.
+            if (imageContent.mimeType === 'image/jpeg' || imageContent.format === 'JPEG' || !imageContent.format) {
+                return `data:image/jpeg;base64,${base64}`;
+            }
+            if (!imageContent.width || !imageContent.height) {
+                return null;
+            }
+            const binary = atob(base64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) {
+                bytes[i] = binary.charCodeAt(i);
+            }
+            return decodeRawImage(imageContent.format, imageContent.width, imageContent.height, bytes);
+        }
+
+        // Populate capture options from tools/list on page load
         window.addEventListener('load', function() {
-            updateStatus('Page loaded. CORS headers enable direct browser access to ESP32-CAM.');
+            updateStatus('Page loaded. Loading capture options from tools/list...');
+            loadToolOptions();
         });
     </script>
 </body>

--- a/browser_controller.html
+++ b/browser_controller.html
@@ -69,6 +69,37 @@
             <select id="capture-pixelformat"></select>
         </div>
 
+        <div class="control-group">
+            <h3>GPIO Controls</h3>
+            <label for="gpio-pin">Pin:</label>
+            <select id="gpio-pin">
+                <option value="2">GPIO2</option>
+                <option value="4">GPIO4</option>
+                <option value="12">GPIO12</option>
+                <option value="13">GPIO13</option>
+                <option value="14">GPIO14</option>
+                <option value="15">GPIO15</option>
+                <option value="33">GPIO33</option>
+            </select>
+            <label for="gpio-mode">Mode:</label>
+            <select id="gpio-mode" onchange="updateGpioControls()">
+                <option value="di">di (digital input)</option>
+                <option value="ai">ai (analog input)</option>
+                <option value="do">do (digital output)</option>
+                <option value="ao">ao (analog output)</option>
+            </select>
+            <span id="gpio-do-value" style="display:none;">
+                <label><input type="radio" name="gpio-do-level" value="true" checked> HIGH</label>
+                <label><input type="radio" name="gpio-do-level" value="false"> LOW</label>
+            </span>
+            <span id="gpio-ao-value" style="display:none;">
+                <label for="gpio-ao-duty">Duty (0-100%):</label>
+                <input type="number" id="gpio-ao-duty" min="0" max="100" value="50">
+            </span>
+            <br><br>
+            <button onclick="gpioRun()">Run GPIO</button>
+        </div>
+
         <div id="status" class="status">Ready to connect...</div>
         
         <div class="control-group">
@@ -332,6 +363,38 @@
             }
         }
 
+        // Shows only the value controls that apply to the currently selected GPIO mode.
+        function updateGpioControls() {
+            const mode = document.getElementById('gpio-mode').value;
+            document.getElementById('gpio-do-value').style.display = (mode === 'do') ? 'inline' : 'none';
+            document.getElementById('gpio-ao-value').style.display = (mode === 'ao') ? 'inline' : 'none';
+        }
+
+        // Reads (di/ai) or writes (do/ao) the selected GPIO pin via the gpio tool.
+        async function gpioRun() {
+            const pin = parseInt(document.getElementById('gpio-pin').value, 10);
+            const mode = document.getElementById('gpio-mode').value;
+            const args = { pin: pin, mode: mode };
+
+            if (mode === 'do') {
+                args.value = document.querySelector('input[name="gpio-do-level"]:checked').value === 'true';
+            } else if (mode === 'ao') {
+                const duty = parseInt(document.getElementById('gpio-ao-duty').value, 10);
+                args.value = isNaN(duty) ? 0 : Math.max(0, Math.min(100, duty));
+            }
+
+            const result = await sendMCPRequest('tools/call', {
+                name: 'gpio',
+                arguments: args
+            });
+
+            if (result) {
+                const value = result.structuredContent && result.structuredContent.value;
+                const action = (mode === 'di' || mode === 'ai') ? 'read value' : 'set value';
+                updateStatus(`GPIO${pin} (${mode}) ${action}: ${value}`);
+            }
+        }
+
         async function getStatus() {
             await sendMCPRequest('tools/call', {
                 name: 'system_status',
@@ -514,6 +577,7 @@
         // Populate capture options from tools/list on page load
         window.addEventListener('load', function() {
             updateStatus('Page loaded. Loading capture options from tools/list...');
+            updateGpioControls();
             loadToolOptions();
         });
     </script>

--- a/browser_controller.html
+++ b/browser_controller.html
@@ -93,8 +93,8 @@
                 <label><input type="radio" name="gpio-do-level" value="false"> LOW</label>
             </span>
             <span id="gpio-ao-value" style="display:none;">
-                <label for="gpio-ao-duty">Duty (0-100%):</label>
-                <input type="number" id="gpio-ao-duty" min="0" max="100" value="50">
+                <label for="gpio-ao-duty">Duty (0-100%, float ok):</label>
+                <input type="number" id="gpio-ao-duty" min="0" max="100" step="any" value="50">
             </span>
             <br><br>
             <button onclick="gpioRun()">Run GPIO</button>
@@ -379,7 +379,7 @@
             if (mode === 'do') {
                 args.value = document.querySelector('input[name="gpio-do-level"]:checked').value === 'true';
             } else if (mode === 'ao') {
-                const duty = parseInt(document.getElementById('gpio-ao-duty').value, 10);
+                const duty = parseFloat(document.getElementById('gpio-ao-duty').value);
                 args.value = isNaN(duty) ? 0 : Math.max(0, Math.min(100, duty));
             }
 

--- a/capture_image.ps1
+++ b/capture_image.ps1
@@ -5,13 +5,13 @@ $esp32_url = "http://esp32-7c9ebdf16a10.local"
 
 # Capture image with flash
 $capture_request = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 1
     method = "tools/call"
     params = @{
         name = "capture"
         arguments = @{
-            flash = "on"
+            flash = $true
         }
     }
 } | ConvertTo-Json -Depth 10

--- a/capture_image.sh
+++ b/capture_image.sh
@@ -12,13 +12,13 @@ echo "Capturing image from ESP32-CAM..."
 RESPONSE=$(curl -s -X POST "$ESP32_URL" \
   -H "Content-Type: application/json" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 1,
     "method": "tools/call",
     "params": {
       "name": "capture",
       "arguments": {
-        "flash": "on"
+        "flash": true
       }
     }
   }')

--- a/include/settings.h
+++ b/include/settings.h
@@ -1,12 +1,12 @@
 #pragma once
 
-constexpr auto MCP_PROTOCOL_VERSION = "2024-11-05";
+constexpr auto MCP_PROTOCOL_VERSION = "2025-06-18";
 constexpr auto MCP_NAME = "ESP32-CAM-AI MCP Server";
 constexpr auto MCP_VERSION = "1.0.1";
 
 // Pixel format for MCP "capture" tool photos (bounds JPEG size and memory)
 constexpr auto MCP_CAPTURE_PIXELFORMAT = PIXFORMAT_JPEG;
-// Maximum resolution for MCP "capture" tool photos (bounds JPEG size and memory)
+// Default resolution for MCP "capture" tool photos (any advertised frame size is honored)
 constexpr auto MCP_CAPTURE_FRAMESIZE = FRAMESIZE_VGA;
 // Default JPEG quality (1-100) for MCP "capture" tool photos
 constexpr auto MCP_CAPTURE_QUALITY = 20;

--- a/include/settings.h
+++ b/include/settings.h
@@ -16,7 +16,6 @@ constexpr auto MAX_MCP_REQUEST_SIZE = 16384; // 16 KB
 // Leave MCP_API_USER empty to disable authentication (open access).
 constexpr auto MCP_API_USER = "";
 constexpr auto MCP_API_PASSWORD = "";
-
-constexpr auto MCP_API_REALM = "ESP32-CAM-AI MCP";
-
-#define MCP_OTA_PASSWORD MCP_API_PASSWORD
+constexpr auto MCP_API_REALM = "ESP32-CAM-AI";
+// Optional OTA password for ArduinoOTA updates. Set to empty string to disable OTA updates.
+constexpr auto MCP_OTA_PASSWORD = "ESP32-CAM-AI"; 

--- a/include/settings.h
+++ b/include/settings.h
@@ -6,6 +6,8 @@ constexpr auto MCP_VERSION = "1.0.1";
 
 // Maximum resolution for MCP "capture" tool photos (bounds JPEG size and memory)
 constexpr auto MCP_CAPTURE_FRAMESIZE = FRAMESIZE_VGA;
+// Default JPEG quality (1-100) for MCP "capture" tool photos
+constexpr auto MCP_CAPTURE_QUALITY = 20;
 
 constexpr auto WATCHDOG_TIMEOUT = 30000UL; // 30 seconds
 // Maximum accepted MCP request body size (bytes)

--- a/include/settings.h
+++ b/include/settings.h
@@ -1,5 +1,22 @@
 #pragma once
 
-#define MCP_PROTOCOL_VERSION "2024-11-05"
-#define MCP_NAME "ESP32-CAM-AI MCP Server"
-#define MCP_VERSION "1.0.1"
+constexpr auto MCP_PROTOCOL_VERSION = "2024-11-05";
+constexpr auto MCP_NAME = "ESP32-CAM-AI MCP Server";
+constexpr auto MCP_VERSION = "1.0.1";
+
+// Maximum resolution for MCP "capture" tool photos (bounds JPEG size and memory)
+constexpr auto MCP_CAPTURE_FRAMESIZE = FRAMESIZE_VGA;
+
+constexpr auto WATCHDOG_TIMEOUT = 30000UL; // 30 seconds
+// Maximum accepted MCP request body size (bytes)
+constexpr auto MAX_MCP_REQUEST_SIZE = 16384; // 16 KB
+
+// Optional API credentials for authenticating MCP requests (HTTP Basic).
+// Set MCP_API_USER (and MCP_API_PASSWORD) here to enable authentication.
+// Leave MCP_API_USER empty to disable authentication (open access).
+constexpr auto MCP_API_USER = "";
+constexpr auto MCP_API_PASSWORD = "";
+
+constexpr auto MCP_API_REALM = "ESP32-CAM-AI MCP";
+
+#define MCP_OTA_PASSWORD MCP_API_PASSWORD

--- a/include/settings.h
+++ b/include/settings.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define MCP_PROTOCOL_VERSION "2024-11-05"
+#define MCP_NAME "ESP32-CAM-AI MCP Server"
+#define MCP_VERSION "1.0.1"

--- a/include/settings.h
+++ b/include/settings.h
@@ -4,10 +4,14 @@ constexpr auto MCP_PROTOCOL_VERSION = "2024-11-05";
 constexpr auto MCP_NAME = "ESP32-CAM-AI MCP Server";
 constexpr auto MCP_VERSION = "1.0.1";
 
+// Pixel format for MCP "capture" tool photos (bounds JPEG size and memory)
+constexpr auto MCP_CAPTURE_PIXELFORMAT = PIXFORMAT_JPEG;
 // Maximum resolution for MCP "capture" tool photos (bounds JPEG size and memory)
 constexpr auto MCP_CAPTURE_FRAMESIZE = FRAMESIZE_VGA;
 // Default JPEG quality (1-100) for MCP "capture" tool photos
 constexpr auto MCP_CAPTURE_QUALITY = 20;
+// Default white balance mode for MCP "capture" tool photos (0=auto, 1=incandescent, 2=fluorescent, 3=warm fluorescent, 4=daylight, 5=cloudy daylight, 6=twilight, 7=shade)
+constexpr auto MCP_CAPTURE_WB_MODE = 0;
 
 constexpr auto WATCHDOG_TIMEOUT = 30000UL; // 30 seconds
 // Maximum accepted MCP request body size (bytes)

--- a/include/tool_schema.h
+++ b/include/tool_schema.h
@@ -1,0 +1,99 @@
+#pragma once
+
+// Fluent helper for building MCP tool input schemas (JSON Schema) with ArduinoJson.
+//
+// ArduinoJson already exposes a "fluent" member-proxy API (doc["a"]["b"] = v), which
+// auto-creates nested objects on assignment. However, declaring tool schemas still
+// requires a lot of boilerplate. This small builder wraps that API so each property
+// can be declared on a single line.
+//
+// Example:
+//   auto tool = tools.add<JsonObject>();
+//   tool_schema schema(tool, "capture", "Captures a photo from the ESP32-CAM");
+//   schema
+//     .boolean("flash", "Use flash when capturing", false)
+//     .number("quality", "JPEG quality for the captured photo (1-100)", 1, 100, 20)
+//     .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes,
+//                 [](const frame_size_entry_t &e) { return e.frame_size == MCP_CAPTURE_FRAMESIZE; });
+
+#include <ArduinoJson.h>
+
+class tool_schema
+{
+public:
+    // Starts a tool definition with a JSON Schema input ("type": "object",
+    // "additionalProperties": false) and an empty "properties" container.
+    tool_schema(JsonObject tool, const char *name, const char *description)
+    {
+        tool["name"] = name;
+        tool["description"] = description;
+        auto schema = tool["inputSchema"].to<JsonObject>();
+        schema["type"] = "object";
+        schema["additionalProperties"] = false;
+        properties_ = schema["properties"].to<JsonObject>();
+    }
+
+    // Declares a string property with a fixed list of enum values.
+    tool_schema &enum_string(const char *key, const char *description, std::initializer_list<const char *> values)
+    {
+        auto property = properties_[key].to<JsonObject>();
+        property["type"] = "string";
+        property["description"] = description;
+        auto enum_values = property["enum"].to<JsonArray>();
+        for (const char *value : values)
+            enum_values.add(value);
+        return *this;
+    }
+
+    // Declares a string property whose enum values (and optional default) are derived
+    // from a lookup table of { name, value } entries (e.g. frame_sizes). is_default
+    // receives each entry and returns true for the entry that should be the default.
+    template <typename T, size_t N, typename IsDefault>
+    tool_schema &enum_table(const char *key, const char *description, const T (&table)[N], IsDefault is_default)
+    {
+        auto property = properties_[key].to<JsonObject>();
+        property["type"] = "string";
+        property["description"] = description;
+        auto enum_values = property["enum"].to<JsonArray>();
+        for (size_t i = 0; i < N; ++i)
+        {
+            enum_values.add(table[i].name);
+            if (is_default(table[i]))
+                property["default"] = table[i].name;
+        }
+        return *this;
+    }
+
+    // Declares a number property with min/max/default constraints.
+    tool_schema &number(const char *key, const char *description, long minimum, long maximum, long default_value)
+    {
+        auto property = properties_[key].to<JsonObject>();
+        property["type"] = "number";
+        property["description"] = description;
+        property["minimum"] = minimum;
+        property["maximum"] = maximum;
+        property["default"] = default_value;
+        return *this;
+    }
+
+    // Declares a boolean property (true/false) with an optional default.
+    tool_schema &boolean(const char *key, const char *description, bool default_value = false)
+    {
+        auto property = properties_[key].to<JsonObject>();
+        property["type"] = "boolean";
+        property["description"] = description;
+        property["default"] = default_value;
+        return *this;
+    }
+
+    // Marks a property as required.
+    tool_schema &required(const char *key)
+    {
+        auto required = properties_[key]["required"].to<JsonArray>();
+        required.add(key);
+        return *this;
+    }
+
+private:
+    JsonObject properties_;
+};

--- a/lib/mcp/mcp.cpp
+++ b/lib/mcp/mcp.cpp
@@ -1,35 +1,35 @@
 #include "mcp.h"
 
-mcp_exception::mcp_exception(error_code code, const String &message)
-    : std::runtime_error(message.c_str()), code_(code)
+mcp_exception::mcp_exception(error_code code, const std::string &message)
+    : std::runtime_error(message), code_(code)
 {
 }
 
-mcp_request::mcp_request(const String &request)
+mcp_request::mcp_request(const std::string &request)
     : jsonrpc_("2.0")
 {
     auto error = deserializeJson(doc_, request);
     if (error)
-        throw mcp_exception(error_code::parse_error, "Failed to parse JSON request: " + String(error.c_str()));
+        throw mcp_exception(error_code::parse_error, "Failed to parse JSON request: " + std::string(error.c_str()));
 
     if (doc_.is<JsonObject>())
     {
         auto request = doc_.as<JsonObject>();
-        if (request["jsonrpc"].is<String>())
-            jsonrpc_ = request["jsonrpc"].as<String>();
+        if (request["jsonrpc"].is<std::string>())
+            jsonrpc_ = request["jsonrpc"].as<std::string>();
 
         if (request["id"].is<JsonVariant>())
             id_ = request["id"];
 
-        if (request["method"].is<String>())
-            method_ = request["method"].as<String>();
+        if (request["method"].is<std::string>())
+            method_ = request["method"].as<std::string>();
 
         if (request["params"].is<JsonObject>())
             params_ = request["params"].as<JsonObject>();
     }
 }
 
-mcp_response::mcp_response(const String &jsonrpc /*= "2.0"*/)
+mcp_response::mcp_response(const std::string &jsonrpc /*= "2.0"*/)
 {
     root_ = doc_.to<JsonObject>();
     root_["jsonrpc"] = jsonrpc;
@@ -51,16 +51,16 @@ JsonObject mcp_response::create_result()
     return root_["result"].to<JsonObject>();
 }
 
-std::tuple<int, const char *, String> mcp_response::get_http_response() const
+std::tuple<int, const char *, std::string> mcp_response::get_http_response() const
 {
-    String json;
+    std::string json;
     try
     {
         serializeJson(doc_, json);
     }
     catch (const std::exception &e)
     {
-        return {500, "text/plain", String("Internal Server Error: ") + String(e.what())}; // Internal Server Error
+        return {500, "text/plain", std::string("Internal Server Error: ") + e.what()}; // Internal Server Error
     }
 
     auto http_code = root_["error"].is<JsonObject>() ? 400 : 200; // If error is present, return 400 Bad Request, else 200 OK

--- a/lib/mcp/mcp.h
+++ b/lib/mcp/mcp.h
@@ -32,22 +32,10 @@ class mcp_request
 public:
     mcp_request(const String &request);
 
-    const String &jsonrpc() const
-    {
-        return jsonrpc_;
-    }
-    const JsonVariant &id() const
-    {
-        return id_;
-    }
-    const String &method() const
-    {
-        return method_;
-    }
-    const JsonObject &params() const
-    {
-        return params_;
-    }
+    const String &jsonrpc() const { return jsonrpc_; }
+    const JsonVariant &id() const { return id_; }
+    const String &method() const { return method_; }
+    const JsonObject &params() const { return params_; }
 
 private:
     JsonDocument doc_;
@@ -65,7 +53,7 @@ struct mcp_response
     JsonObject create_error();
     JsonObject create_result();
 
-    std::tuple<int, const char*, String> get_http_response() const;
+    std::tuple<int, const char *, String> get_http_response() const;
 
 private:
     JsonDocument doc_;

--- a/lib/mcp/mcp.h
+++ b/lib/mcp/mcp.h
@@ -3,6 +3,10 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
 enum error_code
 {
     parse_error = -32700,        // Invalid JSON
@@ -17,7 +21,7 @@ enum error_code
 class mcp_exception : public std::runtime_error
 {
 public:
-    mcp_exception(error_code code, const String &message);
+    mcp_exception(error_code code, const std::string &message);
     error_code code() const
     {
         return code_;
@@ -30,30 +34,30 @@ private:
 class mcp_request
 {
 public:
-    mcp_request(const String &request);
+    mcp_request(const std::string &request);
 
-    const String &jsonrpc() const { return jsonrpc_; }
+    const std::string &jsonrpc() const { return jsonrpc_; }
     const JsonVariant &id() const { return id_; }
-    const String &method() const { return method_; }
+    const std::string &method() const { return method_; }
     const JsonObject &params() const { return params_; }
 
 private:
     JsonDocument doc_;
-    String jsonrpc_;
+    std::string jsonrpc_;
     JsonVariant id_;
-    String method_;
+    std::string method_;
     JsonObject params_;
 };
 
 struct mcp_response
 {
-    mcp_response(const String &jsonrpc = "2.0");
+    mcp_response(const std::string &jsonrpc = "2.0");
 
     mcp_response &set_id(const JsonVariant &id);
     JsonObject create_error();
     JsonObject create_result();
 
-    std::tuple<int, const char *, String> get_http_response() const;
+    std::tuple<int, const char *, std::string> get_http_response() const;
 
 private:
     JsonDocument doc_;

--- a/lib/mcp/mcp_schema_error.h
+++ b/lib/mcp/mcp_schema_error.h
@@ -1,0 +1,76 @@
+#pragma once
+
+// Fluent helper for building MCP JSON-RPC errors with ArduinoJson.
+//
+// Wraps mcp_response so that a JSON-RPC error object
+// ("error": { "code": ..., "message": ..., "data": ... }) can be described
+// fluently. The error object is created lazily on first use.
+//
+// Example:
+//   mcp_schema_error err(response);
+//   err.code(error_code::invalid_params)
+//      .message("Invalid frame_size. Valid options: " + valid_options + ".")
+//      .data("detail");                               // optional error data
+//
+//   mcp_schema_error(response).set(error_code::internal_error, "Camera capture failed");
+//
+// code()/message()/data()/set() return *this, so they can be chained indefinitely.
+
+#include <ArduinoJson.h>
+#include <string>
+#include "mcp.h"
+
+class mcp_schema_error
+{
+public:
+    // Binds the helper to an existing mcp_response.
+    mcp_schema_error(mcp_response &response) : response_(response) {}
+
+    // Sets the JSON-RPC error code (error_code enum).
+    mcp_schema_error &code(error_code value)
+    {
+        ensure_error()["code"] = value;
+        return *this;
+    }
+
+    // Sets the human-readable error message.
+    mcp_schema_error &message(const std::string &value)
+    {
+        ensure_error()["message"] = value;
+        return *this;
+    }
+
+    // Sets the optional JSON-RPC error data (any JSON-serializable value).
+    template <typename T>
+    mcp_schema_error &data(const T &value)
+    {
+        ensure_error()["data"] = value;
+        return *this;
+    }
+
+    // Sets code and message in a single call.
+    mcp_schema_error &set(error_code value, const std::string &message_text)
+    {
+        auto error_object = ensure_error();
+        error_object["code"] = value;
+        error_object["message"] = message_text;
+        return *this;
+    }
+
+    // Raw access to the (lazily created) error object for advanced use.
+    JsonObject error_object()
+    {
+        return ensure_error();
+    }
+
+private:
+    JsonObject ensure_error()
+    {
+        if (!error_)
+            error_ = response_.create_error();
+        return error_;
+    }
+
+    mcp_response &response_;
+    JsonObject error_;
+};

--- a/lib/mcp/mcp_schema_response.h
+++ b/lib/mcp/mcp_schema_response.h
@@ -1,0 +1,98 @@
+#pragma once
+
+// Fluent helper for building MCP responses with ArduinoJson.
+//
+// Wraps mcp_response so that setting the id, adding text content, populating
+// structuredContent, or reporting errors can each be written on a single line
+// and chained fluently. The "result" object (and its content/structuredContent
+// containers) are created lazily, so only what you actually use is emitted.
+//
+// Example:
+//   mcp_response response;
+//   mcp_response_schema r(response);
+//   r.id(request.id())                                  // mirror the request id
+//    .text("Image captured: 640x480")                   // content[0] = { type: text }
+//    .field("width", 640)                               // structuredContent.width
+//    .field("height", 480);                             // structuredContent.height
+//
+//   r.error(error_code::internal_error, "Camera capture failed");
+//
+// text()/field()/error() return *this, so they can be chained indefinitely.
+
+#include <ArduinoJson.h>
+#include <string>
+#include "mcp.h"
+
+class mcp_response_schema
+{
+public:
+    // Binds the helper to an existing mcp_response.
+    mcp_response_schema(mcp_response &response) : response_(response) {}
+
+    // Mirrors the incoming request's JSON-RPC id (e.g. request.id()).
+    mcp_response_schema &id(const JsonVariant &value)
+    {
+        response_.set_id(value);
+        return *this;
+    }
+
+    // Accepts scalar ids (numbers, strings) by buffering them in a local document.
+    template <typename T>
+    mcp_response_schema &id(const T &value)
+    {
+        id_buffer_["v"] = value;
+        response_.set_id(id_buffer_["v"]);
+        return *this;
+    }
+
+    // Explicitly begins the "result" object (text()/field() create it lazily too).
+    mcp_response_schema &result()
+    {
+        result_ = response_.create_result();
+        return *this;
+    }
+
+    // Adds a text content item: "content": [ { "type": "text", "text": ... } ].
+    mcp_response_schema &text(const std::string &text)
+    {
+        ensure_result();
+        if (!content_)
+            content_ = result_["content"].to<JsonArray>();
+        auto item = content_.add<JsonObject>();
+        item["type"] = "text";
+        item["text"] = text;
+        return *this;
+    }
+
+    // Adds a structuredContent field (MCP 2025-06-18+). Accepts any value that
+    // ArduinoJson can serialize (int, float, bool, const char*, std::string, ...).
+    template <typename T>
+    mcp_response_schema &field(const char *key, const T &value)
+    {
+        ensure_result();
+        if (!structured_)
+            structured_ = result_["structuredContent"].to<JsonObject>();
+        structured_[key] = value;
+        return *this;
+    }
+
+    // Raw access to the (lazily created) result object for advanced use.
+    JsonObject result_object()
+    {
+        ensure_result();
+        return result_;
+    }
+
+private:
+    void ensure_result()
+    {
+        if (!result_)
+            result();
+    }
+
+    mcp_response &response_;
+    JsonDocument id_buffer_;
+    JsonObject result_;
+    JsonArray content_;
+    JsonObject structured_;
+};

--- a/lib/mcp/mcp_schema_tool.h
+++ b/lib/mcp/mcp_schema_tool.h
@@ -68,6 +68,15 @@ public:
     }
 
     // Declares a number property with min/max/default constraints.
+    tool_schema &number(const char *key, const char *description)
+    {
+        auto property = properties_[key].to<JsonObject>();
+        property["type"] = "number";
+        property["description"] = description;
+        return *this;
+    }
+
+    // Declares a number property with min/max/default constraints.
     tool_schema &number(const char *key, const char *description, long minimum, long maximum, long default_value)
     {
         auto property = properties_[key].to<JsonObject>();
@@ -86,6 +95,18 @@ public:
         property["type"] = "boolean";
         property["description"] = description;
         property["default"] = default_value;
+        return *this;
+    }
+
+    // Declares a property that accepts either a boolean or a number (union type),
+    // used when the expected value type depends on another argument (e.g. "mode").
+    tool_schema &any(const char *key, const char *description)
+    {
+        auto property = properties_[key].to<JsonObject>();
+        auto types = property["type"].to<JsonArray>();
+        types.add("boolean");
+        types.add("number");
+        property["description"] = description;
         return *this;
     }
 

--- a/lib/mcp/mcp_schema_tool.h
+++ b/lib/mcp/mcp_schema_tool.h
@@ -14,9 +14,12 @@
 //     .boolean("flash", "Use flash when capturing", false)
 //     .number("quality", "JPEG quality for the captured photo (1-100)", 1, 100, 20)
 //     .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes,
-//                 [](const frame_size_entry_t &e) { return e.frame_size == MCP_CAPTURE_FRAMESIZE; });
+//                 [](framesize_t size) { return size == MCP_CAPTURE_FRAMESIZE; });
 
+#include <Arduino.h>
 #include <ArduinoJson.h>
+#include <map>
+#include <string>
 
 class tool_schema
 {
@@ -46,20 +49,20 @@ public:
     }
 
     // Declares a string property whose enum values (and optional default) are derived
-    // from a lookup table of { name, value } entries (e.g. frame_sizes). is_default
-    // receives each entry and returns true for the entry that should be the default.
-    template <typename T, size_t N, typename IsDefault>
-    tool_schema &enum_table(const char *key, const char *description, const T (&table)[N], IsDefault is_default)
+    // from a std::map of { name, value } entries (e.g. frame_sizes). is_default
+    // receives each value and returns true for the entry that should be the default.
+    template <typename T, typename IsDefault>
+    tool_schema &enum_table(const char *key, const char *description, const std::map<std::string, T> &table, IsDefault is_default)
     {
         auto property = properties_[key].to<JsonObject>();
         property["type"] = "string";
         property["description"] = description;
         auto enum_values = property["enum"].to<JsonArray>();
-        for (size_t i = 0; i < N; ++i)
+        for (const auto &entry : table)
         {
-            enum_values.add(table[i].name);
-            if (is_default(table[i]))
-                property["default"] = table[i].name;
+            enum_values.add(entry.first);
+            if (is_default(entry.second))
+                property["default"] = entry.first;
         }
         return *this;
     }

--- a/platformio.ini
+++ b/platformio.ini
@@ -49,7 +49,7 @@ build_type = debug
 [env:esp32cam-release]
 board = esp32cam
 build_flags =
-    -O3
+    -O2
     -DNDEBUG
     -D 'BOARD_NAME="${this.board}"'
     -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_INFO

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 default_envs = esp32cam-release
 
 [env]
-platform = espressif32
+platform = espressif32@7.0.1
 framework = arduino
 extra_scripts = pre:env-extra.py
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 
 #include "camera_config.h"
 #include "settings.h"
+#include "tool_schema.h"
 
 #ifdef ENABLE_GZIP
 // miniz is a small public-domain zlib/gzip alternative commonly available with ESP32 Arduino
@@ -33,8 +34,6 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-// Result of camera initialization
-esp_err_t camera_init_result = ESP_OK;
 // Temperature export (funny; has a typo!)
 #ifdef __cplusplus
 extern "C"
@@ -162,6 +161,16 @@ const framesize_t lookup_frame_size(const char *pin)
     return FRAMESIZE_INVALID;
 }
 
+const char *lookup_frame_size_name(framesize_t size)
+{
+    // Lookup table for framesize_t to a display name
+    for (const auto &entry : frame_sizes)
+        if (entry.frame_size == size)
+            return entry.name;
+
+    return "Unknown";
+}
+
 typedef struct pixel_format_entry
 {
     const char name[12];
@@ -191,6 +200,16 @@ const pixformat_t lookup_pixel_format(const char *pin)
     return PIXFORMAT_INVALID;
 }
 
+const char *lookup_pixel_format_name(pixformat_t fmt)
+{
+    // Lookup table for pixformat_t to a display name
+    for (const auto &entry : pixel_formats)
+        if (entry.pixel_format == fmt)
+            return entry.name;
+
+    return "Unknown";
+}
+
 typedef struct
 {
     const char name[7];
@@ -214,120 +233,60 @@ const int lookup_camera_wb_mode(const char *name)
     return -1; // Not found
 }
 
+const char *lookup_camera_wb_mode_name(int mode)
+{
+    // Lookup table for wb_mode int to a display name
+    for (const auto &entry : camera_wb_modes)
+        if (entry.value == mode)
+            return entry.name;
+
+    return "Unknown";
+}
+
 void handle_tools_list(mcp_response &response)
 {
   auto result = response.create_result();
   auto tools = result["tools"].to<JsonArray>();
 
   // Add LED control tool
-  auto led_tool = tools.add<JsonObject>();
-  led_tool["name"] = "led";
-  led_tool["description"] = "Controls the ESP32-CAM LED state";
-  auto led_tool_input_schema = led_tool["inputSchema"].to<JsonObject>();
-  led_tool_input_schema["type"] = "object";
-  auto led_tool_input_schema_properties = led_tool_input_schema["properties"].to<JsonObject>();
-  auto led_tool_input_schema_properties_state = led_tool_input_schema_properties["state"].to<JsonObject>();
-  led_tool_input_schema_properties_state["type"] = "string";
-  led_tool_input_schema_properties_state["description"] = "LED state";
-  auto led_tool_input_schema_properties_state_enum_array = led_tool_input_schema_properties_state["enum"].to<JsonArray>();
-  led_tool_input_schema_properties_state_enum_array.add("on");
-  led_tool_input_schema_properties_state_enum_array.add("off");
-  auto led_tool_input_schema_properties_state_required = led_tool_input_schema_properties_state["required"].to<JsonArray>();
-  led_tool_input_schema_properties_state_required.add("state");
-  led_tool_input_schema["additionalProperties"] = false;
+  tool_schema led_tool(tools.add<JsonObject>(), "led", "Controls the ESP32-CAM LED state");
+  led_tool.boolean("on", "LED on", false).required("on");
 
-  // Add Flash control tool
-  auto flash_tool = tools.add<JsonObject>();
-  flash_tool["name"] = "flash";
-  flash_tool["description"] = "Controls the ESP32-CAM Flash";
-  auto flash_tool_input_schema = flash_tool["inputSchema"].to<JsonObject>();
-  flash_tool_input_schema["type"] = "object";
-  auto flash_tool_input_schema_properties = flash_tool_input_schema["properties"].to<JsonObject>();
-  auto flash_tool_input_schema_properties_duration = flash_tool_input_schema_properties["duration"].to<JsonObject>();
-  flash_tool_input_schema_properties_duration["description"] = "Flash duration in milliseconds";
-  flash_tool_input_schema_properties_duration["type"] = "number";
-  flash_tool_input_schema_properties_duration["minimum"] = 5;
-  flash_tool_input_schema_properties_duration["maximum"] = 100;
-  flash_tool_input_schema_properties_duration["default"] = 50;
-  flash_tool_input_schema["additionalProperties"] = false;
+  // Add flash control tool
+  tool_schema flash_tool(tools.add<JsonObject>(), "flash", "Controls the ESP32-CAM Flash");
+  flash_tool.number("duration", "Flash duration in milliseconds", 5, 100, 50);
 
   // Add camera capture tool
-  auto camera_tool = tools.add<JsonObject>();
-  camera_tool["name"] = "capture";
-  camera_tool["description"] = "Captures a photo from the ESP32-CAM";
-  auto camera_tool_input_schema = camera_tool["inputSchema"].to<JsonObject>();
-  camera_tool_input_schema["type"] = "object";
-  auto camera_tool_input_schema_properties = camera_tool_input_schema["properties"].to<JsonObject>();
-  auto camera_tool_input_schema_properties_flash = camera_tool_input_schema_properties["flash"].to<JsonObject>();
-  camera_tool_input_schema_properties_flash["type"] = "string";
-  camera_tool_input_schema_properties_flash["description"] = "Use flash when capturing";
-  auto camera_tool_input_schema_properties_flash_enum_array = camera_tool_input_schema_properties_flash["enum"].to<JsonArray>();
-  camera_tool_input_schema_properties_flash_enum_array.add("on");
-  camera_tool_input_schema_properties_flash_enum_array.add("off");
-  auto camera_tool_input_schema_properties_frame_size = camera_tool_input_schema_properties["frame_size"].to<JsonObject>();
-  camera_tool_input_schema_properties_frame_size["type"] = "string";
-  camera_tool_input_schema_properties_frame_size["description"] = "Resolution to use for the captured photo";
-  auto camera_tool_input_schema_properties_frame_size_enum = camera_tool_input_schema_properties_frame_size["enum"].to<JsonArray>();
-  for (const auto &entry : frame_sizes)
-  {
-    camera_tool_input_schema_properties_frame_size_enum.add(entry.name);
-    // Use the configured capture cap (MCP_CAPTURE_FRAMESIZE) as the schema default
-    if (entry.frame_size == MCP_CAPTURE_FRAMESIZE)
-      camera_tool_input_schema_properties_frame_size["default"] = entry.name;
-  }
-  auto camera_tool_input_schema_properties_quality = camera_tool_input_schema_properties["quality"].to<JsonObject>();
-  camera_tool_input_schema_properties_quality["type"] = "number";
-  camera_tool_input_schema_properties_quality["description"] = "JPEG quality for the captured photo (1-100)";
-  camera_tool_input_schema_properties_quality["minimum"] = 1;
-  camera_tool_input_schema_properties_quality["maximum"] = 100;
-  camera_tool_input_schema_properties_quality["default"] = MCP_CAPTURE_QUALITY;
-  auto camera_tool_input_schema_properties_wb_mode = camera_tool_input_schema_properties["whitebalance"].to<JsonObject>();
-  camera_tool_input_schema_properties_wb_mode["type"] = "string";
-  camera_tool_input_schema_properties_wb_mode["description"] = "White balance mode for the captured photo";
-  auto camera_tool_input_schema_properties_wb_mode_enum = camera_tool_input_schema_properties_wb_mode["enum"].to<JsonArray>();
-  for (const auto &entry : camera_wb_modes)
-  {
-    camera_tool_input_schema_properties_wb_mode_enum.add(entry.name);
-    if (entry.value == MCP_CAPTURE_WB_MODE)
-      camera_tool_input_schema_properties_wb_mode["default"] = entry.name;
-  }
-  // Auto is the default white balance mode
-  camera_tool_input_schema_properties_wb_mode["default"] = camera_wb_modes[0].name;
-  auto camera_tool_input_schema_properties_pixelformat = camera_tool_input_schema_properties["pixelformat"].to<JsonObject>();
-  camera_tool_input_schema_properties_pixelformat["type"] = "string";
-  camera_tool_input_schema_properties_pixelformat["description"] = "Pixel format for the captured photo";
-  auto camera_tool_input_schema_properties_pixelformat_enum = camera_tool_input_schema_properties_pixelformat["enum"].to<JsonArray>();
-  for (const auto &entry : pixel_formats)
-  {
-    camera_tool_input_schema_properties_pixelformat_enum.add(entry.name);
-    if (entry.pixel_format == MCP_CAPTURE_PIXELFORMAT)
-      camera_tool_input_schema_properties_pixelformat["default"] = entry.name;
-  }
-  camera_tool_input_schema["additionalProperties"] = false;
+  tool_schema camera_tool(tools.add<JsonObject>(), "capture", "Captures a photo from the ESP32-CAM");
+  camera_tool
+      .boolean("flash", "Use flash when capturing", false)
+      .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes,
+                  [](const frame_size_entry_t &entry) { return entry.frame_size == MCP_CAPTURE_FRAMESIZE; })
+      .number("quality", "JPEG quality for the captured photo (1-100)", 1, 100, MCP_CAPTURE_QUALITY)
+      .enum_table("whitebalance", "White balance mode for the captured photo", camera_wb_modes,
+                  [](const camera_wb_mode_entry_t &entry) { return entry.value == MCP_CAPTURE_WB_MODE; })
+      .enum_table("pixelformat", "Pixel format for the captured photo", pixel_formats,
+                  [](const pixel_format_entry_t &entry) { return entry.pixel_format == MCP_CAPTURE_PIXELFORMAT; });
 
   // Add WiFi status tool
-  auto wifi_tool = tools.add<JsonObject>();
-  wifi_tool["name"] = "wifi_status";
-  wifi_tool["description"] = "Gets current WiFi connection status and network information";
-  auto wifi_tool_input_schema = wifi_tool["inputSchema"].to<JsonObject>();
-  wifi_tool_input_schema["type"] = "object";
-  auto wifi_tool_input_schema_properties = wifi_tool_input_schema["properties"].to<JsonObject>();
-  wifi_tool_input_schema["additionalProperties"] = false;
+  tool_schema wifi_tool(tools.add<JsonObject>(), "wifi_status",
+                        "Gets current WiFi connection status and network information. "
+                        "Returns: ip_address (string, IPv4), signal_strength_dbm (integer, dBm), "
+                        "mac_address (string), gateway (string, IPv4), dns (string, IPv4)");
 
   // Add system status tool
-  auto system_tool = tools.add<JsonObject>();
-  system_tool["name"] = "system_status";
-  system_tool["description"] = "Gets comprehensive system status including memory, uptime, and hardware info";
-  auto system_tool_input_schema = system_tool["inputSchema"].to<JsonObject>();
-  system_tool_input_schema["type"] = "object";
-  auto system_tool_input_schema_properties = system_tool_input_schema["properties"].to<JsonObject>();
-  system_tool_input_schema["additionalProperties"] = false;
+  tool_schema system_tool(tools.add<JsonObject>(), "system_status",
+                          "Gets comprehensive system status including memory, uptime, and hardware info. "
+                          "Returns: uptime_seconds (integer), free_heap_bytes (integer), min_free_heap_bytes (integer), "
+                          "max_alloc_heap_bytes (integer), cpu_frequency_mhz (integer), flash_size_bytes (integer), "
+                          "flash_speed_hz (integer), sketch_size_bytes (integer), free_sketch_space_bytes (integer), "
+                          "sdk_version (string), reset_reason (integer), camera_initialized (boolean), "
+                          "internal_temperature_c (number, °C)");
 }
 
 void tool_led(JsonObject arguments, mcp_response &response)
 {
-  auto state = arguments["state"].as<String>();
-  if (state == "on")
+  if (arguments["on"].as<bool>())
   {
     digitalWrite(LED_GPIO, LED_ON_LEVEL);
     auto result = response.create_result();
@@ -336,7 +295,7 @@ void tool_led(JsonObject arguments, mcp_response &response)
     result_content_item["type"] = "text";
     result_content_item["text"] = "LED turned on";
   }
-  else if (state == "off")
+  else
   {
     digitalWrite(LED_GPIO, LED_ON_LEVEL == LOW ? HIGH : LOW);
     auto result = response.create_result();
@@ -344,12 +303,6 @@ void tool_led(JsonObject arguments, mcp_response &response)
     auto result_content_item = result_content.add<JsonObject>();
     result_content_item["type"] = "text";
     result_content_item["text"] = "LED turned off";
-  }
-  else
-  {
-    auto error = response.create_error();
-    error["code"] = error_code::invalid_params;
-    error["message"] = "Invalid LED state. Use 'on' or 'off'.";
   }
 }
 
@@ -368,16 +321,6 @@ void tool_flash(JsonObject arguments, mcp_response &response)
 
 void tool_capture(JsonObject arguments, mcp_response &response)
 {
-  if (camera_init_result != ESP_OK)
-  {
-    auto error = response.create_error();
-    error["code"] = error_code::internal_error;
-    error["message"] = "Camera not initialized or failed to initialize";
-    return;
-  }
-
-  auto sensor = esp_camera_sensor_get();
-
   // Resolve the requested capture resolution from the frame_size argument (enum)
   auto requested_framesize = FRAMESIZE_INVALID;
   if (!arguments["frame_size"].isNull())
@@ -398,22 +341,10 @@ void tool_capture(JsonObject arguments, mcp_response &response)
       return;
     }
   }
-
-  auto previous_framesize = sensor ? sensor->status.framesize : MCP_CAPTURE_FRAMESIZE;
-  auto capture_framesize = requested_framesize == FRAMESIZE_INVALID ? previous_framesize : requested_framesize;
-
-  // Cap the capture resolution to bound JPEG size and memory usage
-  if (capture_framesize > MCP_CAPTURE_FRAMESIZE)
-    capture_framesize = MCP_CAPTURE_FRAMESIZE;
-  if (sensor && sensor->status.framesize != capture_framesize)
-  {
-    log_d("Capture: setting resolution %d -> %d", sensor->status.framesize, capture_framesize);
-    sensor->set_framesize(sensor, capture_framesize);
-  }
+  auto capture_framesize = requested_framesize == FRAMESIZE_INVALID ? MCP_CAPTURE_FRAMESIZE : requested_framesize;
 
   // Resolve the requested JPEG quality (1-100) from the quality argument
-  auto previous_quality = sensor ? sensor->status.quality : MCP_CAPTURE_QUALITY;
-  auto capture_quality = previous_quality;
+  auto capture_quality = MCP_CAPTURE_QUALITY;
   if (!arguments["quality"].isNull())
   {
     auto quality = arguments["quality"].as<int>();
@@ -426,15 +357,9 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     }
     capture_quality = quality;
   }
-  if (sensor && sensor->status.quality != capture_quality)
-  {
-    log_d("Capture: setting quality %d -> %d", sensor->status.quality, capture_quality);
-    sensor->set_quality(sensor, capture_quality);
-  }
 
   // Resolve the requested white balance mode from the wb_mode argument (enum)
-  auto previous_whitebalance = sensor ? sensor->status.wb_mode : 0;
-  auto capture_whitebalance = previous_whitebalance;
+  auto capture_whitebalance = MCP_CAPTURE_WB_MODE;
   if (!arguments["whitebalance"].isNull())
   {
     auto wb_mode = lookup_camera_wb_mode(arguments["whitebalance"].as<const char *>());
@@ -454,15 +379,9 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     }
     capture_whitebalance = wb_mode;
   }
-  if (sensor && sensor->status.wb_mode != capture_whitebalance)
-  {
-    log_d("Capture: setting wb_mode %d -> %d", sensor->status.wb_mode, capture_whitebalance);
-    sensor->set_wb_mode(sensor, capture_whitebalance);
-  }
 
   // Resolve the requested pixel format from the pixelformat argument (enum)
-  auto previous_pixelformat = sensor ? sensor->pixformat : PIXFORMAT_JPEG;
-  auto capture_pixelformat = previous_pixelformat;
+  auto capture_pixelformat = MCP_CAPTURE_PIXELFORMAT;
   if (!arguments["pixelformat"].isNull())
   {
     auto pixel_format = lookup_pixel_format(arguments["pixelformat"].as<const char *>());
@@ -482,15 +401,29 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     }
     capture_pixelformat = pixel_format;
   }
-  if (sensor && sensor->pixformat != capture_pixelformat)
+
+  // Build the camera configuration with the requested parameters and (re)initialize
+  camera_config_t config = esp32cam_aithinker_settings;
+  config.frame_size = capture_framesize;
+  config.pixel_format = capture_pixelformat;
+  config.jpeg_quality = capture_quality;
+
+  auto camera_init_result = esp_camera_init(&config);
+  if (camera_init_result != ESP_OK)
   {
-    log_d("Capture: setting pixelformat %d -> %d", sensor->pixformat, capture_pixelformat);
-    sensor->set_pixformat(sensor, capture_pixelformat);
+    auto error = response.create_error();
+    error["code"] = error_code::internal_error;
+    error["message"] = "Camera initialization failed (0x" + String(camera_init_result, 16) + ")";
+    return;
   }
+
+  auto sensor = esp_camera_sensor_get();
+  if (sensor)
+    sensor->set_wb_mode(sensor, capture_whitebalance);
+
   log_d("Capture: free heap before capture: %d", ESP.getFreeHeap());
 
-  auto flash = arguments["flash"].as<String>();
-  if (flash == "on")
+  if (arguments["flash"].as<bool>())
   {
     digitalWrite(FLASH_GPIO, FLASH_ON_LEVEL);
     delay(20); // Allow flash to stabilize
@@ -500,18 +433,28 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   auto fb = esp_camera_fb_get();
   if (fb)
     esp_camera_fb_return(fb);
+  else
+    log_w("Capture: warm-up frame failed");
 
   fb = esp_camera_fb_get();
   if (fb)
     esp_camera_fb_return(fb);
+else
+    log_w("Capture: warm-up frame failed");
 
   // Take the actual frame
   fb = esp_camera_fb_get();
+  if (fb)
+    log_d("Capture: captured frame: %u bytes, free heap after capture: %d", (unsigned)fb->len, ESP.getFreeHeap());
+  else
+    log_w("Capture: failed to capture frame, free heap after capture: %d", ESP.getFreeHeap());
+  
   // Turn flash off immediately after capture attempt
   digitalWrite(FLASH_GPIO, !FLASH_ON_LEVEL);
 
   if (!fb)
   {
+    esp_camera_deinit();
     auto error = response.create_error();
     error["code"] = error_code::internal_error;
     error["message"] = "Camera capture failed";
@@ -519,44 +462,45 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   }
 
   auto fb_len = fb->len;
+  auto fb_width = fb->width;
+  auto fb_height = fb->height;
   auto base64_image = base64::encode(fb->buf, fb->len);
   esp_camera_fb_return(fb);
+  esp_camera_deinit();
   log_d("Capture: JPEG %u bytes -> base64 %u bytes, free heap after: %d", (unsigned)fb_len, (unsigned)base64_image.length(), ESP.getFreeHeap());
 
   auto result = response.create_result();
   auto result_content = result["content"].to<JsonArray>();
   auto result_content_item = result_content.add<JsonObject>();
   result_content_item["type"] = "text";
-  result_content_item["text"] = "Image captured successfully. Size: " + String(base64_image.length()) + " bytes (base64 encoded)";
+  auto capture_text = String("Image captured successfully. ");
+  capture_text += "Pixel format: " + String(lookup_pixel_format_name(capture_pixelformat)) + ", ";
+  capture_text += "Frame size: " + String(lookup_frame_size_name(capture_framesize)) + ", ";
+  capture_text += "Quality: " + String(capture_quality) + ", ";
+  capture_text += "White balance: " + String(lookup_camera_wb_mode_name(capture_whitebalance)) + ", ";
+  capture_text += "Flash: " + String(arguments["flash"].as<bool>() ? "on" : "off") + ", ";
+  capture_text += "Dimensions: " + String(fb_width) + "x" + String(fb_height) + ", ";
+  capture_text += "Size: " + String(base64_image.length()) + " bytes (base64 encoded)";
+  result_content_item["text"] = capture_text;
 
-  auto result_content_image_item = result_content.add<JsonObject>();
-  result_content_image_item["type"] = "image";
-  result_content_image_item["data"] = base64_image;
-  result_content_image_item["mimeType"] = "image/jpeg";
+  auto structured = result["structuredContent"].to<JsonObject>();
+  structured["image"] = base64_image;
+  structured["format"] = lookup_pixel_format_name(capture_pixelformat);
+  structured["width"] = fb_width;
+  structured["height"] = fb_height;
+  structured["mimeType"] = capture_pixelformat == PIXFORMAT_JPEG ? "image/jpeg" : "image/x-raw";
   // Free the intermediate base64 String; the JSON document already holds its own copy
   base64_image = String();
-
-  // Restore the previous capture resolution
-  if (sensor && previous_framesize != capture_framesize)
-    sensor->set_framesize(sensor, previous_framesize);
-  // Restore the previous capture quality
-  if (sensor && previous_quality != capture_quality)
-    sensor->set_quality(sensor, previous_quality);
-  // Restore the previous capture white balance mode
-  if (sensor && previous_whitebalance != capture_whitebalance)
-    sensor->set_wb_mode(sensor, previous_whitebalance);
-  // Restore the previous capture pixel format
-  if (sensor && previous_pixelformat != capture_pixelformat)
-    sensor->set_pixformat(sensor, previous_pixelformat);
 }
 
 void tool_wifi_status(mcp_response &response)
 {
   auto result = response.create_result();
   auto result_content = result["content"].to<JsonArray>();
-  auto result_content_item = result_content.add<JsonObject>();
-  result_content_item["type"] = "text";
 
+  // Human-readable text summary
+  auto summary_item = result_content.add<JsonObject>();
+  summary_item["type"] = "text";
   auto status_text = String();
   status_text.reserve(256); // Pre-allocate to avoid repeated reallocations
   status_text += "IP Address: " + WiFi.localIP().toString() + "\n"
@@ -564,17 +508,27 @@ void tool_wifi_status(mcp_response &response)
                  "MAC Address: " + WiFi.macAddress() + "\n"
                  "Gateway: " + WiFi.gatewayIP().toString() + "\n"
                  "DNS: " + WiFi.dnsIP().toString() + "\n";
-  result_content_item["text"] = status_text;
+  summary_item["text"] = status_text;
+
+  // Return the parameters individually as structuredContent (MCP 2025-06-18+)
+  auto structured = result["structuredContent"].to<JsonObject>();
+  structured["ip_address"] = WiFi.localIP().toString();
+  structured["signal_strength_dbm"] = WiFi.RSSI();
+  structured["mac_address"] = WiFi.macAddress();
+  structured["gateway"] = WiFi.gatewayIP().toString();
+  structured["dns"] = WiFi.dnsIP().toString();
 }
 
 void tool_system_status(mcp_response &response)
 {
   auto result = response.create_result();
   auto result_content = result["content"].to<JsonArray>();
-  auto result_content_item = result_content.add<JsonObject>();
-  result_content_item["type"] = "text";
 
   auto internal_temperature = (temprature_sens_read() - 32) / 1.8;
+
+  // Human-readable text summary
+  auto summary_item = result_content.add<JsonObject>();
+  summary_item["type"] = "text";
   auto status_text = String();
   status_text.reserve(1024); // Pre-allocate to avoid repeated reallocations
   status_text += "Uptime: " + String(millis() / 1000) + " seconds\n"
@@ -588,9 +542,23 @@ void tool_system_status(mcp_response &response)
                  "Free Sketch Space: " + String(ESP.getFreeSketchSpace()) + " bytes\n"
                  "SDK Version: " + String(ESP.getSdkVersion()) + "\n"
                  "Reset Reason: " + String(esp_reset_reason()) + "\n"
-                 "Camera initialized: " + String(camera_init_result == ESP_OK ? "Yes" : "No (code = 0x" + String(camera_init_result, 16) + ")") + "\n"
                  "Internal Temperature: " + String(internal_temperature, 2) + " °C\n";
-  result_content_item["text"] = status_text;
+  summary_item["text"] = status_text;
+
+  // Return the parameters individually as structuredContent (MCP 2025-06-18+)
+  auto structured = result["structuredContent"].to<JsonObject>();
+  structured["uptime_seconds"] = millis() / 1000;
+  structured["free_heap_bytes"] = ESP.getFreeHeap();
+  structured["min_free_heap_bytes"] = ESP.getMinFreeHeap();
+  structured["max_alloc_heap_bytes"] = ESP.getMaxAllocHeap();
+  structured["cpu_frequency_mhz"] = getCpuFrequencyMhz();
+  structured["flash_size_bytes"] = ESP.getFlashChipSize();
+  structured["flash_speed_hz"] = ESP.getFlashChipSpeed();
+  structured["sketch_size_bytes"] = ESP.getSketchSize();
+  structured["free_sketch_space_bytes"] = ESP.getFreeSketchSpace();
+  structured["sdk_version"] = ESP.getSdkVersion();
+  structured["reset_reason"] = esp_reset_reason();
+  structured["internal_temperature_c"] = internal_temperature;
 }
 
 void handle_tools_call(const mcp_request &request, mcp_response &response)
@@ -771,12 +739,7 @@ void setup()
   ArduinoOTA.setPassword(MCP_OTA_PASSWORD);
   ArduinoOTA.begin();
 
-  // Initialize camera
-  camera_init_result = esp_camera_init(&esp32cam_aithinker_settings);
-  if (camera_init_result == ESP_OK)
-    log_i("Camera initialized successfully");
-  else
-    log_e("Camera init failed with error 0x%x", camera_init_result);
+  // Camera is initialized on demand inside tool_capture with the requested parameters
 
   // Register request headers to collect so hasHeader()/header() work for Accept-Encoding content negotiation
   const char *headerkeys[] = {"Accept-Encoding"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,9 +33,6 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-// WiFi connection state, updated by WiFi events
-bool wifiConnected = false;
-
 // Result of camera initialization
 esp_err_t camera_init_result = ESP_OK;
 // Temperature export (funny; has a typo!)
@@ -49,6 +46,8 @@ extern "C"
 #endif
 
 WebServer server;
+auto macAddress = String(ESP.getEfuseMac(), 16);
+auto thingName = String("esp") + "-" + macAddress;
 
 // Configured MCP API credentials from settings.h.
 static const String mcp_api_user(MCP_API_USER);
@@ -242,6 +241,37 @@ void tool_flash(JsonObject arguments, mcp_response &response)
   result_content_item["text"] = "Flash executed";
 }
 
+typedef struct frame_size_entry
+{
+    const char name[17];
+    const framesize_t frame_size;
+} frame_size_entry_t;
+
+constexpr const frame_size_entry_t frame_sizes[] = {
+    {"QQVGA (160x120)", FRAMESIZE_QQVGA},
+    {"QCIF (176x144)", FRAMESIZE_QCIF},
+    {"HQVGA (240x176)", FRAMESIZE_HQVGA},
+    {"240x240", FRAMESIZE_240X240},
+    {"QVGA (320x240)", FRAMESIZE_QVGA},
+    {"CIF (400x296)", FRAMESIZE_CIF},
+    {"HVGA (480x320)", FRAMESIZE_HVGA},
+    {"VGA (640x480)", FRAMESIZE_VGA},
+    {"SVGA (800x600)", FRAMESIZE_SVGA},
+    {"XGA (1024x768)", FRAMESIZE_XGA},
+    {"HD (1280x720)", FRAMESIZE_HD},
+    {"SXGA (1280x1024)", FRAMESIZE_SXGA},
+    {"UXGA (1600x1200)", FRAMESIZE_UXGA}};
+
+const framesize_t lookup_frame_size(const char *pin)
+{
+    // Lookup table for the frame name to framesize_t
+    for (const auto &entry : frame_sizes)
+        if (strncmp(entry.name, pin, sizeof(entry.name)) == 0)
+            return entry.frame_size;
+
+    return FRAMESIZE_INVALID;
+}
+
 void tool_capture(JsonObject arguments, mcp_response &response)
 {
   if (camera_init_result != ESP_OK)
@@ -322,11 +352,12 @@ void tool_wifi_status(mcp_response &response)
   result_content_item["type"] = "text";
 
   auto status_text = String();
-  status_text += "IP Address: " + WiFi.localIP().toString() + "\n";
-  status_text += "Signal Strength: " + String(WiFi.RSSI()) + " dBm\n";
-  status_text += "MAC Address: " + WiFi.macAddress() + "\n";
-  status_text += "Gateway: " + WiFi.gatewayIP().toString() + "\n";
-  status_text += "DNS: " + WiFi.dnsIP().toString() + "\n";
+  status_text.reserve(256); // Pre-allocate to avoid repeated reallocations
+  status_text += "IP Address: " + WiFi.localIP().toString() + "\n"
+                 "Signal Strength: " + String(WiFi.RSSI()) + " dBm\n"
+                 "MAC Address: " + WiFi.macAddress() + "\n"
+                 "Gateway: " + WiFi.gatewayIP().toString() + "\n"
+                 "DNS: " + WiFi.dnsIP().toString() + "\n";
   result_content_item["text"] = status_text;
 }
 
@@ -337,23 +368,22 @@ void tool_system_status(mcp_response &response)
   auto result_content_item = result_content.add<JsonObject>();
   result_content_item["type"] = "text";
 
-  // Get the tem
-
-  auto status_text = String("System Status:\n");
-  status_text += "Uptime: " + String(millis() / 1000) + " seconds\n";
-  status_text += "Free Heap: " + String(ESP.getFreeHeap()) + " bytes\n";
-  status_text += "Min Free Heap: " + String(ESP.getMinFreeHeap()) + " bytes\n";
-  status_text += "Max Alloc Heap: " + String(ESP.getMaxAllocHeap()) + " bytes\n";
-  status_text += "CPU Frequency: " + String(getCpuFrequencyMhz()) + " MHz\n";
-  status_text += "Flash Size: " + String(ESP.getFlashChipSize()) + " bytes\n";
-  status_text += "Flash Speed: " + String(ESP.getFlashChipSpeed()) + " Hz\n";
-  status_text += "Sketch Size: " + String(ESP.getSketchSize()) + " bytes\n";
-  status_text += "Free Sketch Space: " + String(ESP.getFreeSketchSpace()) + " bytes\n";
-  status_text += "SDK Version: " + String(ESP.getSdkVersion()) + "\n";
-  status_text += "Reset Reason: " + String(esp_reset_reason()) + "\n";
-  status_text += "Camera initialized: " + String(camera_init_result == ESP_OK ? "Yes" : "No (code = 0x" + String(camera_init_result, 16) + ")") + "\n";
   auto internal_temperature = (temprature_sens_read() - 32) / 1.8;
-  status_text += "Internal Temperature: " + String(internal_temperature, 2) + " °C\n";
+  auto status_text = String();
+  status_text.reserve(1024); // Pre-allocate to avoid repeated reallocations
+  status_text += "Uptime: " + String(millis() / 1000) + " seconds\n"
+                 "Free Heap: " + String(ESP.getFreeHeap()) + " bytes\n"
+                 "Min Free Heap: " + String(ESP.getMinFreeHeap()) + " bytes\n"
+                 "Max Alloc Heap: " + String(ESP.getMaxAllocHeap()) + " bytes\n"
+                 "CPU Frequency: " + String(getCpuFrequencyMhz()) + " MHz\n"
+                 "Flash Size: " + String(ESP.getFlashChipSize()) + " bytes\n"
+                 "Flash Speed: " + String(ESP.getFlashChipSpeed()) + " Hz\n"
+                 "Sketch Size: " + String(ESP.getSketchSize()) + " bytes\n"
+                 "Free Sketch Space: " + String(ESP.getFreeSketchSpace()) + " bytes\n"
+                 "SDK Version: " + String(ESP.getSdkVersion()) + "\n"
+                 "Reset Reason: " + String(esp_reset_reason()) + "\n"
+                 "Camera initialized: " + String(camera_init_result == ESP_OK ? "Yes" : "No (code = 0x" + String(camera_init_result, 16) + ")") + "\n"
+                 "Internal Temperature: " + String(internal_temperature, 2) + " °C\n";
   result_content_item["text"] = status_text;
 }
 
@@ -491,32 +521,6 @@ void handleRoot()
   server.send(http_code, content_type, body);
 }
 
-// WiFi event handlers
-void onWiFiEvent(WiFiEvent_t event)
-{
-  switch (event)
-  {
-  case ARDUINO_EVENT_WIFI_STA_CONNECTED:
-    log_d("WiFi connected to SSID: %s", WiFi.SSID().c_str());
-    break;
-
-  case ARDUINO_EVENT_WIFI_STA_GOT_IP:
-    log_d("WiFi got IP address: %s", WiFi.localIP().toString().c_str());
-    wifiConnected = true;
-    break;
-
-  case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
-    log_d("WiFi disconnected!");
-    wifiConnected = false;
-    break;
-
-  case ARDUINO_EVENT_WIFI_STA_LOST_IP:
-    log_d("WiFi lost IP address");
-    wifiConnected = false;
-    break;
-  }
-}
-
 void setup()
 {
   // Disable brownout
@@ -533,9 +537,6 @@ void setup()
   log_d("CPU Freq: %d Mhz", getCpuFrequencyMhz());
   log_d("Free heap: %d bytes", ESP.getFreeHeap());
 
-  // Setup WiFi event handlers
-  WiFi.onEvent(onWiFiEvent);
-
   // Configure WiFi for automatic reconnection on disconnect
   WiFi.setAutoReconnect(true); // Auto-reconnect to the saved AP
   WiFi.persistent(true);       // Save WiFi config to flash
@@ -549,13 +550,10 @@ void setup()
     ESP.restart();
   }
 
-  wifiConnected = true; // Set initial status
   log_i("Local IP address: %s", WiFi.localIP().toString().c_str());
   log_d("Signal strength: %d dBm", WiFi.RSSI());
 
-  auto hostName = "esp32-" + WiFi.macAddress() + ".local";
-  hostName.replace(":", "");
-  hostName.toLowerCase();
+  auto hostName = "esp32-" + macAddress + ".local";
   log_i("mDNS hostname: %s", hostName.c_str());
   MDNS.begin(hostName.c_str());
   MDNS.addService("_jsonrpc", "_tcp", 80);
@@ -585,7 +583,7 @@ void setup()
 void loop()
 {
   // Handle web server requests only if WiFi is connected
-  if (wifiConnected)
+  if (WiFi.status() == WL_CONNECTED)
     server.handleClient();
 
   // Handle OTA (works even with WiFi issues for recovery)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <base64.h>
 
 #include "camera_config.h"
+#include "settings.h"
 
 #ifdef ENABLE_GZIP
 // miniz is a small public-domain zlib/gzip alternative commonly available with ESP32 Arduino
@@ -31,18 +32,9 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-// WiFi reconnection settings
-constexpr auto WIFI_REBOOT_DELAY = 60000UL;       // 60 seconds
-constexpr auto WIFI_RECONNECT_INTERVAL = 30000UL; // 30 seconds
-constexpr auto WIFI_CHECK_INTERVAL = 5000UL;      // 5 seconds
-constexpr auto MAX_RECONNECT_ATTEMPTS = 5;
-
 constexpr auto WATCHDOG_TIMEOUT = 30000UL; // 30 seconds
 
-// WiFi status tracking
-unsigned long lastWiFiCheck = 0;
-unsigned long lastReconnectAttempt = 0;
-int reconnectAttempts = 0;
+// WiFi connection state, updated by WiFi events
 bool wifiConnected = false;
 
 // Result of camera initialization
@@ -81,12 +73,10 @@ static bool deflate_compress(const String &input, String &output)
   if (!buf)
     return false;
   auto out_len = bound;
-  auto st = mz_compress2(buf.get(), &out_len, src, src_len, MZ_DEFAULT_LEVEL);
-  if (st != MZ_OK)
-  {
+  if (mz_compress2(buf.get(), &out_len, src, src_len, MZ_DEFAULT_LEVEL) != MZ_OK)
     return false;
-  }
-  output = String(reinterpret_cast<const char *>(buf.get()), static_cast<unsigned int>(out_len));
+
+    output = String(reinterpret_cast<const char *>(buf.get()), static_cast<unsigned int>(out_len));
   return true;
 }
 #endif
@@ -94,13 +84,13 @@ static bool deflate_compress(const String &input, String &output)
 void handle_initialize(mcp_response &response)
 {
   auto result = response.create_result();
-  result["protocolVersion"] = "2024-11-05";
+  result["protocolVersion"] = MCP_PROTOCOL_VERSION;
   auto capabilities = result["capabilities"].to<JsonObject>();
   auto tools = capabilities["tools"].to<JsonObject>();
   tools["listChanged"] = false;
   auto server_info = result["serverInfo"].to<JsonObject>();
-  server_info["name"] = "ESP32-CAM-AI MCP Server";
-  server_info["version"] = "1.0.1";
+  server_info["name"] = MCP_NAME;
+  server_info["version"] = MCP_VERSION;
 }
 
 void handle_notifications_initialized(mcp_response &response)
@@ -180,73 +170,6 @@ void handle_tools_list(mcp_response &response)
   system_tool_input_schema["type"] = "object";
   auto system_tool_input_schema_properties = system_tool_input_schema["properties"].to<JsonObject>();
   system_tool_input_schema["additionalProperties"] = false;
-}
-
-void checkWiFiConnection()
-{
-  auto now = millis();
-  // Check WiFi status periodically
-  if (now - lastWiFiCheck >= WIFI_CHECK_INTERVAL)
-  {
-    lastWiFiCheck = now;
-    auto currentStatus = WiFi.status() == WL_CONNECTED;
-    // Status changed
-    if (currentStatus != wifiConnected)
-    {
-      wifiConnected = currentStatus;
-      if (wifiConnected)
-      {
-        log_i("WiFi reconnected! IP: %s", WiFi.localIP().toString().c_str());
-        log_i("Signal strength: %d dBm", WiFi.RSSI());
-        reconnectAttempts = 0; // Reset counter on successful connection
-      }
-      else
-      {
-        log_w("WiFi disconnected!");
-      }
-    }
-
-    // Attempt reconnection if disconnected
-    if (!wifiConnected && (now - lastReconnectAttempt >= WIFI_RECONNECT_INTERVAL))
-    {
-      lastReconnectAttempt = now;
-      if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS)
-      {
-        reconnectAttempts++;
-        log_i("WiFi reconnection attempt %d/%d", reconnectAttempts, MAX_RECONNECT_ATTEMPTS);
-
-        WiFi.disconnect();
-        delay(1000);
-        WiFi.begin(STR(WIFI_SSID), STR(WIFI_PASSWORD));
-
-        // Wait for connection with timeout
-        auto connectStart = millis();
-        while (WiFi.status() != WL_CONNECTED && (millis() - connectStart) < 10000)
-          delay(500);
-
-        if (WiFi.status() == WL_CONNECTED)
-        {
-          wifiConnected = true;
-          log_i("WiFi reconnected successfully! IP: %s", WiFi.localIP().toString().c_str());
-          reconnectAttempts = 0;
-        }
-        else
-        {
-          log_w("WiFi reconnection attempt %d failed", reconnectAttempts);
-        }
-      }
-      else
-      {
-        log_e("Max WiFi reconnection attempts reached. Will restart in 60 seconds...");
-        // Reset attempt counter and wait longer before restart
-        if (now - lastReconnectAttempt >= WIFI_REBOOT_DELAY)
-        {
-          log_e("Restarting ESP32 due to WiFi connection failure...");
-          ESP.restart();
-        }
-      }
-    }
-  }
 }
 
 void tool_led(JsonObject arguments, mcp_response &response)
@@ -516,7 +439,6 @@ void onWiFiEvent(WiFiEvent_t event)
   case ARDUINO_EVENT_WIFI_STA_GOT_IP:
     log_d("WiFi got IP address: %s", WiFi.localIP().toString().c_str());
     wifiConnected = true;
-    reconnectAttempts = 0;
     break;
 
   case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
@@ -550,9 +472,9 @@ void setup()
   // Setup WiFi event handlers
   WiFi.onEvent(onWiFiEvent);
 
-  // Configure WiFi for better stability
-  WiFi.setAutoReconnect(false); // We handle reconnection manually
-  WiFi.persistent(true);        // Save WiFi config to flash
+  // Configure WiFi for automatic reconnection on disconnect
+  WiFi.setAutoReconnect(true); // Auto-reconnect to the saved AP
+  WiFi.persistent(true);       // Save WiFi config to flash
 
   log_d("WiFi.begin() with SSID: %s", STR(WIFI_SSID));
   WiFi.begin(STR(WIFI_SSID), STR(WIFI_PASSWORD));
@@ -587,15 +509,16 @@ void setup()
   else
     log_e("Camera init failed with error 0x%x", camera_init_result);
 
+  // Register request headers to collect so hasHeader()/header() work for Accept-Encoding content negotiation
+  const char* headerkeys[] = {"Accept-Encoding"};
+  server.collectHeaders(headerkeys, 1);
+
   server.on("/", HTTP_ANY, handleRoot);
   server.begin();
 }
 
 void loop()
 {
-  // Check WiFi connection status and handle reconnection first
-  checkWiFiConnection();
-
   // Handle web server requests only if WiFi is connected
   if (wifiConnected)
     server.handleClient();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,9 @@
 #include <ArduinoOTA.h>
 #include <esp_camera.h>
 #include <soc/rtc_cntl_reg.h>
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
 #include <map>
 #include <string>
 
@@ -87,11 +90,22 @@ static const std::map<int, uint8_t> gpio_pwm_channels = {
     {33, 9}}; // RED LED
 
 // PWM settings for analog output mode (duty cycle given as a percentage).
-static constexpr uint32_t GPIO_PWM_FREQ = 5000;    // Hz
-static constexpr uint8_t GPIO_PWM_RESOLUTION = 8;  // bits -> duty 0..255
-static constexpr uint32_t GPIO_PWM_MAX_DUTY = 255; // (1 << resolution) - 1
+// 13-bit resolution (duty 0..8191) makes sub-1% values usable: 0.1% -> ~8 steps.
+// 13 bits is the max resolution that still supports 5 kHz on the 80 MHz APB clock
+// (max freq = 80 MHz / 2^13 ~ 9.7 kHz; 14 bits would cap at ~4.8 kHz).
+static constexpr uint32_t GPIO_PWM_FREQ = 5000;                          // Hz
+static constexpr uint8_t GPIO_PWM_RESOLUTION = 13;                       // bits -> duty 0..8191
+static constexpr uint32_t GPIO_PWM_MAX_DUTY = (1U << GPIO_PWM_RESOLUTION) - 1; // 8191
 // Full-scale ADC reference (mV) used to express an analog input as a percentage.
 static constexpr uint32_t GPIO_ADC_REFERENCE_MV = 3300;
+
+// Formats a float for display, dropping trailing zeros (e.g. "0.5", "1", "12.34").
+static std::string format_float(float value)
+{
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%g", value);
+  return std::string(buf);
+}
 
 // Minimal base64 encoder (RFC 4648), used to carry the SRTP master key and salt in the "a=crypto" attribute.
 std::string base64_encode(const uint8_t *data, size_t len)
@@ -126,21 +140,32 @@ extern "C"
 #endif
 
 WebServer server;
-auto macAddress = String(ESP.getEfuseMac(), 16);
-auto thingName = String("esp") + "-" + macAddress;
+// Hex-encoded MAC address (Arduino boundary: ESP.getEfuseMac() -> hex String) used for a unique mDNS hostname.
+auto macAddress = std::string(String(ESP.getEfuseMac(), 16).c_str());
+auto thingName = "esp-" + macAddress;
 
 // Configured MCP API credentials from settings.h.
-static const String mcp_api_user(MCP_API_USER);
-static const String mcp_api_password(MCP_API_PASSWORD);
+static const std::string mcp_api_user(MCP_API_USER);
+static const std::string mcp_api_password(MCP_API_PASSWORD);
 
 // Generic Accept-Encoding check
 static bool client_accepts(const char *encoding)
 {
   if (!server.hasHeader("Accept-Encoding"))
     return false;
-  auto accept = server.header("Accept-Encoding");
-  accept.toLowerCase();
-  return accept.indexOf(encoding) >= 0;
+  auto accept = std::string(server.header("Accept-Encoding").c_str());
+  std::transform(accept.begin(), accept.end(), accept.begin(), ::tolower);
+  return accept.find(encoding) != std::string::npos;
+}
+
+// Strips leading/trailing ASCII whitespace (mirrors Arduino String::trim()).
+static std::string trim_whitespace(const std::string &value)
+{
+  auto first = value.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos)
+    return "";
+  auto last = value.find_last_not_of(" \t\r\n");
+  return value.substr(first, last - first + 1);
 }
 
 // Returns true if the request is authorized. Authentication is disabled when
@@ -148,29 +173,28 @@ static bool client_accepts(const char *encoding)
 // credentials (Authorization: Basic base64(user:password)).
 static bool request_authorized()
 {
-  if (mcp_api_user.length() == 0)
+  if (mcp_api_user.empty())
     return true;
 
-  auto auth = server.header("Authorization");
-  if (!auth.startsWith("Basic "))
+  auto auth = std::string(server.header("Authorization").c_str());
+  if (auth.rfind("Basic ", 0) != 0)
     return false;
 
-  auto encoded = auth.substring(6);
-  encoded.trim();
+  auto encoded = trim_whitespace(auth.substr(6));
 
   auto expected = mcp_api_user + ":" + mcp_api_password;
   auto decoded_len = base64_decode_expected_len(encoded.length()) + 1;
   std::unique_ptr<char[]> decoded(new char[decoded_len]);
-  auto len = base64_decode_chars(encoded.c_str(), encoded.length(), decoded.get());
+  auto len = base64_decode_chars(encoded.c_str(), static_cast<int>(encoded.length()), decoded.get());
   if (len < 0)
     return false;
   decoded[len] = '\0';
-  return String(decoded.get()) == expected;
+  return expected == decoded.get();
 }
 
 #ifdef ENABLE_GZIP
 // Optional deflate (zlib) compression using miniz. Returns true on success and writes binary data to output.
-static bool deflate_compress(const String &input, String &output)
+static bool deflate_compress(const std::string &input, std::string &output)
 {
   auto src = reinterpret_cast<const unsigned char *>(input.c_str());
   auto src_len = static_cast<mz_ulong>(input.length());
@@ -183,7 +207,7 @@ static bool deflate_compress(const String &input, String &output)
   if (mz_compress2(buf.get(), &out_len, src, src_len, MZ_DEFAULT_LEVEL) != MZ_OK)
     return false;
 
-  output = String(reinterpret_cast<const char *>(buf.get()), static_cast<unsigned int>(out_len));
+  output.assign(reinterpret_cast<const char *>(buf.get()), static_cast<size_t>(out_len));
   return true;
 }
 #endif
@@ -262,7 +286,7 @@ void handle_tools_list(mcp_response &response)
   gpio_tool
       .number("pin", "GPIO pin to control. Valid pins: 2, 4, 12, 13, 14, 15, 33")
       .enum_string("mode", "Pin mode", {"di", "ai", "do", "ao"})
-      .any("value", "Required for output modes. do: true (HIGH) or false (LOW). ao: 0-100 (duty cycle percentage).")
+      .any("value", "Required for output modes. do: true (HIGH) or false (LOW). ao: 0-100 (duty cycle percentage; float accepted, e.g. 0.5 = 0.5%).")
       .required("pin")
       .required("mode");
 }
@@ -297,7 +321,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   auto capture_framesize = MCP_CAPTURE_FRAMESIZE;
   if (!arguments["frame_size"].isNull())
   {
-    auto frame_size_it = frame_sizes.find(arguments["frame_size"].as<const char *>());
+    auto frame_size_it = frame_sizes.find(arguments["frame_size"].as<std::string>());
     if (frame_size_it == frame_sizes.end())
     {
       std::string valid_options;
@@ -334,7 +358,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   auto capture_whitebalance = MCP_CAPTURE_WB_MODE;
   if (!arguments["whitebalance"].isNull())
   {
-    auto wb_mode_it = camera_wb_modes.find(arguments["whitebalance"].as<const char *>());
+    auto wb_mode_it = camera_wb_modes.find(arguments["whitebalance"].as<std::string>());
     if (wb_mode_it == camera_wb_modes.end())
     {
       std::string valid_options;
@@ -356,7 +380,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   auto capture_pixelformat = MCP_CAPTURE_PIXELFORMAT;
   if (!arguments["pixelformat"].isNull())
   {
-    auto pixel_format_it = pixel_formats.find(arguments["pixelformat"].as<const char *>());
+    auto pixel_format_it = pixel_formats.find(arguments["pixelformat"].as<std::string>());
     if (pixel_format_it == pixel_formats.end())
     {
       std::string valid_options;
@@ -585,7 +609,7 @@ void tool_gpio(JsonObject arguments, mcp_response &response)
       .message("Mode is required. Valid modes: di (digital input), ai (analog input), do (digital output), ao (analog output).");
     return;
   }
-  auto mode = arguments["mode"].as<String>();
+  auto mode = arguments["mode"].as<std::string>();
 
   if (mode == "di")
   {
@@ -663,12 +687,15 @@ void tool_gpio(JsonObject arguments, mcp_response &response)
     auto channel = channel_it->second;
     ledcSetup(channel, GPIO_PWM_FREQ, GPIO_PWM_RESOLUTION);
     ledcAttachPin(pin, channel);
-    auto duty = (uint32_t)(percent / 100.0f * (float)GPIO_PWM_MAX_DUTY + 0.5f);
-    if (duty > GPIO_PWM_MAX_DUTY)
-      duty = GPIO_PWM_MAX_DUTY;
-    ledcWrite(channel, duty);
+    // Duty cycle is kept as a float so sub-1% values stay representable; it is rounded to the nearest integer step only when written to the LEDC hardware.
+    auto duty = percent / 100.0f * (float)GPIO_PWM_MAX_DUTY;
+    auto duty_step = (uint32_t)(duty + 0.5f);
+    if (duty_step > GPIO_PWM_MAX_DUTY)
+      duty_step = GPIO_PWM_MAX_DUTY;
+    ledcWrite(channel, duty_step);
+    log_d("GPIO%d analog output: %.3f%% -> duty %.3f/%u, step %u", pin, percent, duty, (unsigned)GPIO_PWM_MAX_DUTY, (unsigned)duty_step);
 
-    auto text = std::string("Pin GPIO") + std::to_string(pin) + " PWM duty set to " + std::to_string((int)(percent + 0.5f)) + "% (duty " + std::to_string(duty) + "/" + std::to_string(GPIO_PWM_MAX_DUTY) + ")";
+    auto text = std::string("Pin GPIO") + std::to_string(pin) + " PWM duty set to " + format_float(percent) + "% (duty " + format_float(duty) + "/" + std::to_string(GPIO_PWM_MAX_DUTY) + ")";
     mcp_response_schema r(response);
     r.text(text)
       .field("pin", pin)
@@ -688,7 +715,7 @@ void tool_gpio(JsonObject arguments, mcp_response &response)
 void handle_tools_call(const mcp_request &request, mcp_response &response)
 {
   auto params = request.params();
-  auto tool_name = params["name"].as<String>();
+  auto tool_name = params["name"].as<std::string>();
   auto arguments = params["arguments"].as<JsonObject>();
 
   if (tool_name == "led")
@@ -706,14 +733,14 @@ void handle_tools_call(const mcp_request &request, mcp_response &response)
   else
   {
     // Tool not found, set error
-    if (tool_name.isEmpty())
+    if (tool_name.empty())
       mcp_schema_error(response)
         .code(error_code::invalid_request)
         .message("Tool name is required");
     else
       mcp_schema_error(response)
         .code(error_code::method_not_found)
-        .message(std::string(("Unknown tool: " + tool_name).c_str()));
+        .message("Unknown tool: " + tool_name);
   }
 }
 
@@ -761,7 +788,7 @@ void handleRoot()
   mcp_response mcp_response;
   try
   {
-    mcp_request mcp_request(server.arg("plain"));
+    mcp_request mcp_request(std::string(server.arg("plain").c_str()));
     mcp_response.set_id(mcp_request.id());
 
     // Handle MCP methods
@@ -781,7 +808,7 @@ void handleRoot()
     else
       mcp_schema_error(mcp_response)
         .code(error_code::method_not_found)
-        .message(std::string(("Method not found: " + mcp_request.method()).c_str()));
+        .message("Method not found: " + mcp_request.method());
   }
   catch (const mcp_exception &e)
   {
@@ -800,12 +827,15 @@ void handleRoot()
   // Try deflate if the client accepts it; fall back to plain text on any failure
   if (client_accepts("deflate"))
   {
-    String deflated;
+    std::string deflated;
     if (deflate_compress(body, deflated))
     {
       server.sendHeader("Content-Encoding", "deflate");
       log_d("Sending deflate response: %d %s len=%u (deflate)", http_code, content_type, (unsigned)deflated.length());
-      server.send(http_code, content_type, deflated);
+      // Send with an explicit length: the deflated payload is binary and may contain
+      // embedded NUL bytes, so the const char* overload (which uses strlen/String())
+      // would truncate it. The String(const char*, unsigned int) overload preserves it.
+      server.send(http_code, content_type, String(deflated.data(), static_cast<unsigned int>(deflated.size())));
       return;
     }
   }
@@ -813,7 +843,7 @@ void handleRoot()
 
   // Deflate not enabled or failed, fall back to plain text
   log_d("Sending response: %d %s len=%u", http_code, content_type, (unsigned)body.length());
-  server.send(http_code, content_type, body);
+  server.send(http_code, content_type, body.c_str());
 }
 
 void setup()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 
 #include <mcp.h>
 #include <base64.h>
+#include <libb64/cdecode.h>
 
 #include "camera_config.h"
 #include "settings.h"
@@ -32,8 +33,6 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-constexpr auto WATCHDOG_TIMEOUT = 30000UL; // 30 seconds
-
 // WiFi connection state, updated by WiFi events
 bool wifiConnected = false;
 
@@ -49,7 +48,11 @@ extern "C"
 }
 #endif
 
-WebServer server(80);
+WebServer server;
+
+// Configured MCP API credentials from settings.h.
+static const String mcp_api_user(MCP_API_USER);
+static const String mcp_api_password(MCP_API_PASSWORD);
 
 // Generic Accept-Encoding check
 static bool client_accepts(const char *encoding)
@@ -59,6 +62,31 @@ static bool client_accepts(const char *encoding)
   auto accept = server.header("Accept-Encoding");
   accept.toLowerCase();
   return accept.indexOf(encoding) >= 0;
+}
+
+// Returns true if the request is authorized. Authentication is disabled when
+// MCP_API_USER is empty; otherwise the request must present valid HTTP Basic
+// credentials (Authorization: Basic base64(user:password)).
+static bool request_authorized()
+{
+  if (mcp_api_user.length() == 0)
+    return true;
+
+  auto auth = server.header("Authorization");
+  if (!auth.startsWith("Basic "))
+    return false;
+
+  auto encoded = auth.substring(6);
+  encoded.trim();
+
+  auto expected = mcp_api_user + ":" + mcp_api_password;
+  auto decoded_len = base64_decode_expected_len(encoded.length()) + 1;
+  std::unique_ptr<char[]> decoded(new char[decoded_len]);
+  auto len = base64_decode_chars(encoded.c_str(), encoded.length(), decoded.get());
+  if (len < 0)
+    return false;
+  decoded[len] = '\0';
+  return String(decoded.get()) == expected;
 }
 
 #ifdef ENABLE_GZIP
@@ -76,7 +104,7 @@ static bool deflate_compress(const String &input, String &output)
   if (mz_compress2(buf.get(), &out_len, src, src_len, MZ_DEFAULT_LEVEL) != MZ_OK)
     return false;
 
-    output = String(reinterpret_cast<const char *>(buf.get()), static_cast<unsigned int>(out_len));
+  output = String(reinterpret_cast<const char *>(buf.get()), static_cast<unsigned int>(out_len));
   return true;
 }
 #endif
@@ -224,6 +252,16 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     return;
   }
 
+  // Cap the capture resolution to bound JPEG size and memory usage
+  auto sensor = esp_camera_sensor_get();
+  auto previous_framesize = sensor ? sensor->status.framesize : MCP_CAPTURE_FRAMESIZE;
+  if (sensor && sensor->status.framesize > MCP_CAPTURE_FRAMESIZE)
+  {
+    log_d("Capture: lowering resolution %d -> %d", sensor->status.framesize, MCP_CAPTURE_FRAMESIZE);
+    sensor->set_framesize(sensor, MCP_CAPTURE_FRAMESIZE);
+  }
+  log_d("Capture: free heap before capture: %d", ESP.getFreeHeap());
+
   auto flash = arguments["flash"].as<String>();
   if (flash == "on")
   {
@@ -232,7 +270,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   }
 
   // Discard 1-2 warm-up frames to ensure a fresh capture
-  auto fb  = esp_camera_fb_get();
+  auto fb = esp_camera_fb_get();
   if (fb)
     esp_camera_fb_return(fb);
 
@@ -253,8 +291,10 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     return;
   }
 
+  auto fb_len = fb->len;
   auto base64_image = base64::encode(fb->buf, fb->len);
   esp_camera_fb_return(fb);
+  log_d("Capture: JPEG %u bytes -> base64 %u bytes, free heap after: %d", (unsigned)fb_len, (unsigned)base64_image.length(), ESP.getFreeHeap());
 
   auto result = response.create_result();
   auto result_content = result["content"].to<JsonArray>();
@@ -266,6 +306,12 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   result_content_image_item["type"] = "image";
   result_content_image_item["data"] = base64_image;
   result_content_image_item["mimeType"] = "image/jpeg";
+  // Free the intermediate base64 String; the JSON document already holds its own copy
+  base64_image = String();
+
+  // Restore the previous capture resolution
+  if (sensor && previous_framesize != MCP_CAPTURE_FRAMESIZE)
+    sensor->set_framesize(sensor, previous_framesize);
 }
 
 void tool_wifi_status(mcp_response &response)
@@ -367,6 +413,24 @@ void handleRoot()
     return;
   }
 
+  // Enforce optional token authentication
+  if (!request_authorized())
+  {
+    server.sendHeader("WWW-Authenticate", String("Bearer realm=\"") + MCP_API_REALM + "\"");
+    log_w("Unauthorized request from %s", server.client().remoteIP().toString().c_str());
+    server.send(401, "text/plain", "Unauthorized");
+    return;
+  }
+
+  // Reject oversized request bodies before parsing them
+  auto content_length = server.clientContentLength();
+  if (content_length > MAX_MCP_REQUEST_SIZE)
+  {
+    log_w("Rejecting request: Content-Length %d exceeds %d bytes limit", content_length, MAX_MCP_REQUEST_SIZE);
+    server.send(413, "text/plain", "Payload Too Large");
+    return;
+  }
+
   mcp_response mcp_response;
   try
   {
@@ -420,7 +484,7 @@ void handleRoot()
       return;
     }
   }
-#endif  
+#endif
 
   // Deflate not enabled or failed, fall back to plain text
   log_d("Sending response: %d %s len=%u", http_code, content_type, (unsigned)body.length());
@@ -460,7 +524,7 @@ void setup()
 
   Serial.begin(115200);
 
-    // Initialize LED GPIOs
+  // Initialize LED GPIOs
   pinMode(LED_GPIO, OUTPUT);
   digitalWrite(LED_GPIO, LED_ON_LEVEL == LOW ? HIGH : LOW); // Start with LED off
   pinMode(FLASH_GPIO, OUTPUT);
@@ -499,7 +563,8 @@ void setup()
   MDNS.addServiceTxt("_jsonrpc", "_tcp", "protocol", "http");
   MDNS.addServiceTxt("_jsonrpc", "_tcp", "path", "/");
 
-  // Allow over the air updates
+  // Allow over the air updates (optionally password-protected)
+  ArduinoOTA.setPassword(MCP_OTA_PASSWORD);
   ArduinoOTA.begin();
 
   // Initialize camera
@@ -510,7 +575,7 @@ void setup()
     log_e("Camera init failed with error 0x%x", camera_init_result);
 
   // Register request headers to collect so hasHeader()/header() work for Accept-Encoding content negotiation
-  const char* headerkeys[] = {"Accept-Encoding"};
+  const char *headerkeys[] = {"Accept-Encoding"};
   server.collectHeaders(headerkeys, 1);
 
   server.on("/", HTTP_ANY, handleRoot);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,37 @@ void handle_notifications_initialized(mcp_response &response)
   result["acknowledged"] = true;
 }
 
+typedef struct frame_size_entry
+{
+    const char name[17];
+    const framesize_t frame_size;
+} frame_size_entry_t;
+
+constexpr const frame_size_entry_t frame_sizes[] = {
+    {"QQVGA (160x120)", FRAMESIZE_QQVGA},
+    {"QCIF (176x144)", FRAMESIZE_QCIF},
+    {"HQVGA (240x176)", FRAMESIZE_HQVGA},
+    {"240x240", FRAMESIZE_240X240},
+    {"QVGA (320x240)", FRAMESIZE_QVGA},
+    {"CIF (400x296)", FRAMESIZE_CIF},
+    {"HVGA (480x320)", FRAMESIZE_HVGA},
+    {"VGA (640x480)", FRAMESIZE_VGA},
+    {"SVGA (800x600)", FRAMESIZE_SVGA},
+    {"XGA (1024x768)", FRAMESIZE_XGA},
+    {"HD (1280x720)", FRAMESIZE_HD},
+    {"SXGA (1280x1024)", FRAMESIZE_SXGA},
+    {"UXGA (1600x1200)", FRAMESIZE_UXGA}};
+
+const framesize_t lookup_frame_size(const char *pin)
+{
+    // Lookup table for the frame name to framesize_t
+    for (const auto &entry : frame_sizes)
+        if (strncmp(entry.name, pin, sizeof(entry.name)) == 0)
+            return entry.frame_size;
+
+    return FRAMESIZE_INVALID;
+}
+
 void handle_tools_list(mcp_response &response)
 {
   auto result = response.create_result();
@@ -178,6 +209,17 @@ void handle_tools_list(mcp_response &response)
   auto camera_tool_input_schema_properties_flash_enum_array = camera_tool_input_schema_properties_flash["enum"].to<JsonArray>();
   camera_tool_input_schema_properties_flash_enum_array.add("on");
   camera_tool_input_schema_properties_flash_enum_array.add("off");
+  auto camera_tool_input_schema_properties_frame_size = camera_tool_input_schema_properties["frame_size"].to<JsonObject>();
+  camera_tool_input_schema_properties_frame_size["type"] = "string";
+  camera_tool_input_schema_properties_frame_size["description"] = "Resolution to use for the captured photo";
+  auto camera_tool_input_schema_properties_frame_size_enum = camera_tool_input_schema_properties_frame_size["enum"].to<JsonArray>();
+  for (const auto &entry : frame_sizes)
+  {
+    camera_tool_input_schema_properties_frame_size_enum.add(entry.name);
+    // Use the configured capture cap (MCP_CAPTURE_FRAMESIZE) as the schema default
+    if (entry.frame_size == MCP_CAPTURE_FRAMESIZE)
+      camera_tool_input_schema_properties_frame_size["default"] = entry.name;
+  }
   camera_tool_input_schema["additionalProperties"] = false;
 
   // Add WiFi status tool
@@ -241,37 +283,6 @@ void tool_flash(JsonObject arguments, mcp_response &response)
   result_content_item["text"] = "Flash executed";
 }
 
-typedef struct frame_size_entry
-{
-    const char name[17];
-    const framesize_t frame_size;
-} frame_size_entry_t;
-
-constexpr const frame_size_entry_t frame_sizes[] = {
-    {"QQVGA (160x120)", FRAMESIZE_QQVGA},
-    {"QCIF (176x144)", FRAMESIZE_QCIF},
-    {"HQVGA (240x176)", FRAMESIZE_HQVGA},
-    {"240x240", FRAMESIZE_240X240},
-    {"QVGA (320x240)", FRAMESIZE_QVGA},
-    {"CIF (400x296)", FRAMESIZE_CIF},
-    {"HVGA (480x320)", FRAMESIZE_HVGA},
-    {"VGA (640x480)", FRAMESIZE_VGA},
-    {"SVGA (800x600)", FRAMESIZE_SVGA},
-    {"XGA (1024x768)", FRAMESIZE_XGA},
-    {"HD (1280x720)", FRAMESIZE_HD},
-    {"SXGA (1280x1024)", FRAMESIZE_SXGA},
-    {"UXGA (1600x1200)", FRAMESIZE_UXGA}};
-
-const framesize_t lookup_frame_size(const char *pin)
-{
-    // Lookup table for the frame name to framesize_t
-    for (const auto &entry : frame_sizes)
-        if (strncmp(entry.name, pin, sizeof(entry.name)) == 0)
-            return entry.frame_size;
-
-    return FRAMESIZE_INVALID;
-}
-
 void tool_capture(JsonObject arguments, mcp_response &response)
 {
   if (camera_init_result != ESP_OK)
@@ -282,13 +293,39 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     return;
   }
 
-  // Cap the capture resolution to bound JPEG size and memory usage
   auto sensor = esp_camera_sensor_get();
-  auto previous_framesize = sensor ? sensor->status.framesize : MCP_CAPTURE_FRAMESIZE;
-  if (sensor && sensor->status.framesize > MCP_CAPTURE_FRAMESIZE)
+
+  // Resolve the requested capture resolution from the frame_size argument (enum)
+  auto requested_framesize = FRAMESIZE_INVALID;
+  if (arguments.containsKey("frame_size"))
   {
-    log_d("Capture: lowering resolution %d -> %d", sensor->status.framesize, MCP_CAPTURE_FRAMESIZE);
-    sensor->set_framesize(sensor, MCP_CAPTURE_FRAMESIZE);
+    requested_framesize = lookup_frame_size(arguments["frame_size"].as<const char *>());
+    if (requested_framesize == FRAMESIZE_INVALID)
+    {
+      String valid_options;
+      for (const auto &entry : frame_sizes)
+      {
+        if (!valid_options.isEmpty())
+          valid_options += ", ";
+        valid_options += entry.name;
+      }
+      auto error = response.create_error();
+      error["code"] = error_code::invalid_params;
+      error["message"] = "Invalid frame_size. Valid options: " + valid_options + ".";
+      return;
+    }
+  }
+
+  auto previous_framesize = sensor ? sensor->status.framesize : MCP_CAPTURE_FRAMESIZE;
+  auto capture_framesize = requested_framesize == FRAMESIZE_INVALID ? previous_framesize : requested_framesize;
+
+  // Cap the capture resolution to bound JPEG size and memory usage
+  if (capture_framesize > MCP_CAPTURE_FRAMESIZE)
+    capture_framesize = MCP_CAPTURE_FRAMESIZE;
+  if (sensor && sensor->status.framesize != capture_framesize)
+  {
+    log_d("Capture: setting resolution %d -> %d", sensor->status.framesize, capture_framesize);
+    sensor->set_framesize(sensor, capture_framesize);
   }
   log_d("Capture: free heap before capture: %d", ESP.getFreeHeap());
 
@@ -340,7 +377,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   base64_image = String();
 
   // Restore the previous capture resolution
-  if (sensor && previous_framesize != MCP_CAPTURE_FRAMESIZE)
+  if (sensor && previous_framesize != capture_framesize)
     sensor->set_framesize(sensor, previous_framesize);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,14 +5,17 @@
 #include <ArduinoOTA.h>
 #include <esp_camera.h>
 #include <soc/rtc_cntl_reg.h>
+#include <map>
+#include <string>
 
 #include <mcp.h>
-#include <base64.h>
 #include <libb64/cdecode.h>
 
 #include "camera_config.h"
 #include "settings.h"
-#include "tool_schema.h"
+#include "mcp_schema_tool.h"
+#include "mcp_schema_response.h"
+#include "mcp_schema_error.h"
 
 #ifdef ENABLE_GZIP
 // miniz is a small public-domain zlib/gzip alternative commonly available with ESP32 Arduino
@@ -33,6 +36,61 @@
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
+
+static const std::map<std::string, framesize_t> frame_sizes = {
+    {"QQVGA (160x120)", FRAMESIZE_QQVGA},
+    {"QCIF (176x144)", FRAMESIZE_QCIF},
+    {"HQVGA (240x176)", FRAMESIZE_HQVGA},
+    {"240x240", FRAMESIZE_240X240},
+    {"QVGA (320x240)", FRAMESIZE_QVGA},
+    {"CIF (400x296)", FRAMESIZE_CIF},
+    {"HVGA (480x320)", FRAMESIZE_HVGA},
+    {"VGA (640x480)", FRAMESIZE_VGA},
+    {"SVGA (800x600)", FRAMESIZE_SVGA},
+    {"XGA (1024x768)", FRAMESIZE_XGA},
+    {"HD (1280x720)", FRAMESIZE_HD},
+    {"SXGA (1280x1024)", FRAMESIZE_SXGA},
+    {"UXGA (1600x1200)", FRAMESIZE_UXGA}};
+
+static const std::map<std::string, pixformat_t> pixel_formats = {
+    {"RGB565", PIXFORMAT_RGB565},
+    {"YUV422", PIXFORMAT_YUV422},
+    {"YUV420", PIXFORMAT_YUV420},
+    {"Grayscale", PIXFORMAT_GRAYSCALE},
+    {"JPEG", PIXFORMAT_JPEG},
+    {"RGB888", PIXFORMAT_RGB888},
+    {"RAW", PIXFORMAT_RAW},
+    {"RGB444", PIXFORMAT_RGB444},
+    {"RGB555", PIXFORMAT_RGB555}};
+
+static const std::map<std::string, int> camera_wb_modes = {
+    {"Auto", 0},
+    {"Sunny", 1},
+    {"Cloudy", 2},
+    {"Office", 3},
+    {"Home", 4}};
+
+// Minimal base64 encoder (RFC 4648), used to carry the SRTP master key and salt in the "a=crypto" attribute.
+std::string base64_encode(const uint8_t *data, size_t len)
+{
+    static const char table_b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    for (size_t i = 0; i < len; i += 3)
+    {
+        auto n = (uint32_t)data[i] << 16;
+        if (i + 1 < len)
+            n |= (uint32_t)data[i + 1] << 8;
+        if (i + 2 < len)
+            n |= data[i + 2];
+
+        out += table_b64[(n >> 18) & 0x3f];
+        out += table_b64[(n >> 12) & 0x3f];
+        out += (i + 1 < len) ? table_b64[(n >> 6) & 0x3f] : '=';
+        out += (i + 2 < len) ? table_b64[n & 0x3f] : '=';
+    }
+    return out;
+}
 
 // Temperature export (funny; has a typo!)
 #ifdef __cplusplus
@@ -109,14 +167,12 @@ static bool deflate_compress(const String &input, String &output)
 
 void handle_initialize(mcp_response &response)
 {
-  auto result = response.create_result();
+  mcp_response_schema r(response);
+  auto result = r.result_object();
   result["protocolVersion"] = MCP_PROTOCOL_VERSION;
-  auto capabilities = result["capabilities"].to<JsonObject>();
-  auto tools = capabilities["tools"].to<JsonObject>();
-  tools["listChanged"] = false;
-  auto server_info = result["serverInfo"].to<JsonObject>();
-  server_info["name"] = MCP_NAME;
-  server_info["version"] = MCP_VERSION;
+  result["capabilities"]["tools"]["listChanged"] = false;
+  result["serverInfo"]["name"] = MCP_NAME;
+  result["serverInfo"]["version"] = MCP_VERSION;
 }
 
 void handle_notifications_initialized(mcp_response &response)
@@ -125,122 +181,6 @@ void handle_notifications_initialized(mcp_response &response)
   // Set empty result to indicate successful notification processing
   auto result = response.create_result();
   result["acknowledged"] = true;
-}
-
-// pixformat_t and the PIXFORMAT_* values are provided by esp_camera.h (sensor.h);
-// see the pixel_formats lookup table below.
-
-typedef struct frame_size_entry
-{
-    const char name[17];
-    const framesize_t frame_size;
-} frame_size_entry_t;
-
-constexpr const frame_size_entry_t frame_sizes[] = {
-    {"QQVGA (160x120)", FRAMESIZE_QQVGA},
-    {"QCIF (176x144)", FRAMESIZE_QCIF},
-    {"HQVGA (240x176)", FRAMESIZE_HQVGA},
-    {"240x240", FRAMESIZE_240X240},
-    {"QVGA (320x240)", FRAMESIZE_QVGA},
-    {"CIF (400x296)", FRAMESIZE_CIF},
-    {"HVGA (480x320)", FRAMESIZE_HVGA},
-    {"VGA (640x480)", FRAMESIZE_VGA},
-    {"SVGA (800x600)", FRAMESIZE_SVGA},
-    {"XGA (1024x768)", FRAMESIZE_XGA},
-    {"HD (1280x720)", FRAMESIZE_HD},
-    {"SXGA (1280x1024)", FRAMESIZE_SXGA},
-    {"UXGA (1600x1200)", FRAMESIZE_UXGA}};
-
-const framesize_t lookup_frame_size(const char *pin)
-{
-    // Lookup table for the frame name to framesize_t
-    for (const auto &entry : frame_sizes)
-        if (strncmp(entry.name, pin, sizeof(entry.name)) == 0)
-            return entry.frame_size;
-
-    return FRAMESIZE_INVALID;
-}
-
-const char *lookup_frame_size_name(framesize_t size)
-{
-    // Lookup table for framesize_t to a display name
-    for (const auto &entry : frame_sizes)
-        if (entry.frame_size == size)
-            return entry.name;
-
-    return "Unknown";
-}
-
-typedef struct pixel_format_entry
-{
-    const char name[12];
-    const pixformat_t pixel_format;
-} pixel_format_entry_t;
-
-constexpr const pixel_format_entry_t pixel_formats[] = {
-    {"RGB565", PIXFORMAT_RGB565},
-    {"YUV422", PIXFORMAT_YUV422},
-    {"YUV420", PIXFORMAT_YUV420},
-    {"Grayscale", PIXFORMAT_GRAYSCALE},
-    {"JPEG", PIXFORMAT_JPEG},
-    {"RGB888", PIXFORMAT_RGB888},
-    {"RAW", PIXFORMAT_RAW},
-    {"RGB444", PIXFORMAT_RGB444},
-    {"RGB555", PIXFORMAT_RGB555}};
-
-constexpr auto PIXFORMAT_INVALID = static_cast<pixformat_t>(0xff);
-
-const pixformat_t lookup_pixel_format(const char *pin)
-{
-    // Lookup table for the pixel format name to pixformat_t
-    for (const auto &entry : pixel_formats)
-        if (strncmp(entry.name, pin, sizeof(entry.name)) == 0)
-            return entry.pixel_format;
-
-    return PIXFORMAT_INVALID;
-}
-
-const char *lookup_pixel_format_name(pixformat_t fmt)
-{
-    // Lookup table for pixformat_t to a display name
-    for (const auto &entry : pixel_formats)
-        if (entry.pixel_format == fmt)
-            return entry.name;
-
-    return "Unknown";
-}
-
-typedef struct
-{
-    const char name[7];
-    const int value;
-} camera_wb_mode_entry_t;
-
-constexpr const camera_wb_mode_entry_t camera_wb_modes[] = {
-    {"Auto", 0},
-    {"Sunny", 1},
-    {"Cloudy", 2},
-    {"Office", 3},
-    {"Home", 4}};
-
-const int lookup_camera_wb_mode(const char *name)
-{
-    // Lookup table for the white balance name to wb_mode int
-    for (const auto &entry : camera_wb_modes)
-        if (strncmp(entry.name, name, sizeof(entry.name)) == 0)
-            return entry.value;
-
-    return -1; // Not found
-}
-
-const char *lookup_camera_wb_mode_name(int mode)
-{
-    // Lookup table for wb_mode int to a display name
-    for (const auto &entry : camera_wb_modes)
-        if (entry.value == mode)
-            return entry.name;
-
-    return "Unknown";
 }
 
 void handle_tools_list(mcp_response &response)
@@ -260,13 +200,10 @@ void handle_tools_list(mcp_response &response)
   tool_schema camera_tool(tools.add<JsonObject>(), "capture", "Captures a photo from the ESP32-CAM");
   camera_tool
       .boolean("flash", "Use flash when capturing", false)
-      .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes,
-                  [](const frame_size_entry_t &entry) { return entry.frame_size == MCP_CAPTURE_FRAMESIZE; })
+      .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes, [](framesize_t size) { return size == MCP_CAPTURE_FRAMESIZE; })
       .number("quality", "JPEG quality for the captured photo (1-100)", 1, 100, MCP_CAPTURE_QUALITY)
-      .enum_table("whitebalance", "White balance mode for the captured photo", camera_wb_modes,
-                  [](const camera_wb_mode_entry_t &entry) { return entry.value == MCP_CAPTURE_WB_MODE; })
-      .enum_table("pixelformat", "Pixel format for the captured photo", pixel_formats,
-                  [](const pixel_format_entry_t &entry) { return entry.pixel_format == MCP_CAPTURE_PIXELFORMAT; });
+      .enum_table("whitebalance", "White balance mode for the captured photo", camera_wb_modes, [](int mode) { return mode == MCP_CAPTURE_WB_MODE; })
+      .enum_table("pixelformat", "Pixel format for the captured photo", pixel_formats, [](pixformat_t fmt) { return fmt == MCP_CAPTURE_PIXELFORMAT; });
 
   // Add WiFi status tool
   tool_schema wifi_tool(tools.add<JsonObject>(), "wifi_status",
@@ -286,23 +223,16 @@ void handle_tools_list(mcp_response &response)
 
 void tool_led(JsonObject arguments, mcp_response &response)
 {
+  mcp_response_schema r(response);
   if (arguments["on"].as<bool>())
   {
     digitalWrite(LED_GPIO, LED_ON_LEVEL);
-    auto result = response.create_result();
-    auto result_content = result["content"].to<JsonArray>();
-    auto result_content_item = result_content.add<JsonObject>();
-    result_content_item["type"] = "text";
-    result_content_item["text"] = "LED turned on";
+    r.text("LED turned on");
   }
   else
   {
     digitalWrite(LED_GPIO, LED_ON_LEVEL == LOW ? HIGH : LOW);
-    auto result = response.create_result();
-    auto result_content = result["content"].to<JsonArray>();
-    auto result_content_item = result_content.add<JsonObject>();
-    result_content_item["type"] = "text";
-    result_content_item["text"] = "LED turned off";
+    r.text("LED turned off");
   }
 }
 
@@ -312,36 +242,32 @@ void tool_flash(JsonObject arguments, mcp_response &response)
   digitalWrite(FLASH_GPIO, FLASH_ON_LEVEL);
   delay(duration); // 5-100ms
   digitalWrite(FLASH_GPIO, !FLASH_ON_LEVEL);
-  auto result = response.create_result();
-  auto result_content = result["content"].to<JsonArray>();
-  auto result_content_item = result_content.add<JsonObject>();
-  result_content_item["type"] = "text";
-  result_content_item["text"] = "Flash executed";
+  mcp_response_schema(response).text("Flash executed");
 }
 
 void tool_capture(JsonObject arguments, mcp_response &response)
 {
   // Resolve the requested capture resolution from the frame_size argument (enum)
-  auto requested_framesize = FRAMESIZE_INVALID;
+  auto capture_framesize = MCP_CAPTURE_FRAMESIZE;
   if (!arguments["frame_size"].isNull())
   {
-    requested_framesize = lookup_frame_size(arguments["frame_size"].as<const char *>());
-    if (requested_framesize == FRAMESIZE_INVALID)
+    auto frame_size_it = frame_sizes.find(arguments["frame_size"].as<const char *>());
+    if (frame_size_it == frame_sizes.end())
     {
-      String valid_options;
+      std::string valid_options;
       for (const auto &entry : frame_sizes)
       {
-        if (!valid_options.isEmpty())
+        if (!valid_options.empty())
           valid_options += ", ";
-        valid_options += entry.name;
+        valid_options += entry.first;
       }
-      auto error = response.create_error();
-      error["code"] = error_code::invalid_params;
-      error["message"] = "Invalid frame_size. Valid options: " + valid_options + ".";
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Invalid frame_size. Valid options: " + valid_options + ".");
       return;
     }
+    capture_framesize = frame_size_it->second;
   }
-  auto capture_framesize = requested_framesize == FRAMESIZE_INVALID ? MCP_CAPTURE_FRAMESIZE : requested_framesize;
 
   // Resolve the requested JPEG quality (1-100) from the quality argument
   auto capture_quality = MCP_CAPTURE_QUALITY;
@@ -350,9 +276,9 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     auto quality = arguments["quality"].as<int>();
     if (quality < 1 || quality > 100)
     {
-      auto error = response.create_error();
-      error["code"] = error_code::invalid_params;
-      error["message"] = "Invalid quality. Must be between 1 and 100.";
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Invalid quality. Must be between 1 and 100.");
       return;
     }
     capture_quality = quality;
@@ -362,44 +288,44 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   auto capture_whitebalance = MCP_CAPTURE_WB_MODE;
   if (!arguments["whitebalance"].isNull())
   {
-    auto wb_mode = lookup_camera_wb_mode(arguments["whitebalance"].as<const char *>());
-    if (wb_mode < 0)
+    auto wb_mode_it = camera_wb_modes.find(arguments["whitebalance"].as<const char *>());
+    if (wb_mode_it == camera_wb_modes.end())
     {
-      String valid_options;
+      std::string valid_options;
       for (const auto &entry : camera_wb_modes)
       {
-        if (!valid_options.isEmpty())
+        if (!valid_options.empty())
           valid_options += ", ";
-        valid_options += entry.name;
+        valid_options += entry.first;
       }
-      auto error = response.create_error();
-      error["code"] = error_code::invalid_params;
-      error["message"] = "Invalid whitebalance. Valid options: " + valid_options + ".";
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Invalid whitebalance. Valid options: " + valid_options + ".");
       return;
     }
-    capture_whitebalance = wb_mode;
+    capture_whitebalance = wb_mode_it->second;
   }
 
   // Resolve the requested pixel format from the pixelformat argument (enum)
   auto capture_pixelformat = MCP_CAPTURE_PIXELFORMAT;
   if (!arguments["pixelformat"].isNull())
   {
-    auto pixel_format = lookup_pixel_format(arguments["pixelformat"].as<const char *>());
-    if (pixel_format == PIXFORMAT_INVALID)
+    auto pixel_format_it = pixel_formats.find(arguments["pixelformat"].as<const char *>());
+    if (pixel_format_it == pixel_formats.end())
     {
-      String valid_options;
+      std::string valid_options;
       for (const auto &entry : pixel_formats)
       {
-        if (!valid_options.isEmpty())
+        if (!valid_options.empty())
           valid_options += ", ";
-        valid_options += entry.name;
+        valid_options += entry.first;
       }
-      auto error = response.create_error();
-      error["code"] = error_code::invalid_params;
-      error["message"] = "Invalid pixelformat. Valid options: " + valid_options + ".";
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Invalid pixelformat. Valid options: " + valid_options + ".");
       return;
     }
-    capture_pixelformat = pixel_format;
+    capture_pixelformat = pixel_format_it->second;
   }
 
   // Build the camera configuration with the requested parameters and (re)initialize
@@ -411,9 +337,9 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   auto camera_init_result = esp_camera_init(&config);
   if (camera_init_result != ESP_OK)
   {
-    auto error = response.create_error();
-    error["code"] = error_code::internal_error;
-    error["message"] = "Camera initialization failed (0x" + String(camera_init_result, 16) + ")";
+    mcp_schema_error(response)
+        .code(error_code::internal_error)
+        .message("Camera initialization failed (0x" + std::string(String(camera_init_result, 16).c_str()) + ")");
     return;
   }
 
@@ -455,110 +381,107 @@ else
   if (!fb)
   {
     esp_camera_deinit();
-    auto error = response.create_error();
-    error["code"] = error_code::internal_error;
-    error["message"] = "Camera capture failed";
+    mcp_schema_error(response)
+      .code(error_code::internal_error)
+      .message("Camera capture failed");
     return;
   }
 
   auto fb_len = fb->len;
   auto fb_width = fb->width;
   auto fb_height = fb->height;
-  auto base64_image = base64::encode(fb->buf, fb->len);
+  auto base64_image = base64_encode(fb->buf, fb->len);
   esp_camera_fb_return(fb);
   esp_camera_deinit();
   log_d("Capture: JPEG %u bytes -> base64 %u bytes, free heap after: %d", (unsigned)fb_len, (unsigned)base64_image.length(), ESP.getFreeHeap());
 
-  auto result = response.create_result();
-  auto result_content = result["content"].to<JsonArray>();
-  auto result_content_item = result_content.add<JsonObject>();
-  result_content_item["type"] = "text";
-  auto capture_text = String("Image captured successfully. ");
-  capture_text += "Pixel format: " + String(lookup_pixel_format_name(capture_pixelformat)) + ", ";
-  capture_text += "Frame size: " + String(lookup_frame_size_name(capture_framesize)) + ", ";
-  capture_text += "Quality: " + String(capture_quality) + ", ";
-  capture_text += "White balance: " + String(lookup_camera_wb_mode_name(capture_whitebalance)) + ", ";
-  capture_text += "Flash: " + String(arguments["flash"].as<bool>() ? "on" : "off") + ", ";
-  capture_text += "Dimensions: " + String(fb_width) + "x" + String(fb_height) + ", ";
-  capture_text += "Size: " + String(base64_image.length()) + " bytes (base64 encoded)";
-  result_content_item["text"] = capture_text;
+  // Resolve display names for the summary (reverse lookup over the maps)
+  const char *frame_size_name = "Unknown";
+  for (const auto &entry : frame_sizes)
+    if (entry.second == capture_framesize) { frame_size_name = entry.first.c_str(); break; }
+  const char *pixel_format_name = "Unknown";
+  for (const auto &entry : pixel_formats)
+    if (entry.second == capture_pixelformat) { pixel_format_name = entry.first.c_str(); break; }
+  const char *wb_mode_name = "Unknown";
+  for (const auto &entry : camera_wb_modes)
+    if (entry.second == capture_whitebalance) { wb_mode_name = entry.first.c_str(); break; }
 
-  auto structured = result["structuredContent"].to<JsonObject>();
-  structured["image"] = base64_image;
-  structured["format"] = lookup_pixel_format_name(capture_pixelformat);
-  structured["width"] = fb_width;
-  structured["height"] = fb_height;
-  structured["mimeType"] = capture_pixelformat == PIXFORMAT_JPEG ? "image/jpeg" : "image/x-raw";
-  // Free the intermediate base64 String; the JSON document already holds its own copy
-  base64_image = String();
+  // Human-readable text summary
+  std::string text =
+      "Image captured successfully. "
+      "Pixel format: " + std::string(pixel_format_name) + ", "
+      "Frame size: " + std::string(frame_size_name) + ", "
+      "Quality: " + std::to_string(capture_quality) + ", "
+      "White balance: " + std::string(wb_mode_name) + ", "
+      "Flash: " + std::string(arguments["flash"].as<bool>() ? "on" : "off") + ", "
+      "Dimensions: " + std::to_string(fb_width) + "x" + std::to_string(fb_height) + ", "
+      "Size: " + std::to_string(base64_image.length()) + " bytes (base64 encoded)";
+
+  mcp_response_schema r(response);
+  r.text(text)
+      .field("image", base64_image)
+      .field("format", pixel_format_name)
+      .field("width", fb_width)
+      .field("height", fb_height)
+      .field("mimeType", capture_pixelformat == PIXFORMAT_JPEG ? "image/jpeg" : "image/x-raw");
+  // The JSON document already holds its own copy of the image data
+  base64_image.clear();
 }
 
 void tool_wifi_status(mcp_response &response)
 {
-  auto result = response.create_result();
-  auto result_content = result["content"].to<JsonArray>();
-
   // Human-readable text summary
-  auto summary_item = result_content.add<JsonObject>();
-  summary_item["type"] = "text";
-  auto status_text = String();
-  status_text.reserve(256); // Pre-allocate to avoid repeated reallocations
-  status_text += "IP Address: " + WiFi.localIP().toString() + "\n"
-                 "Signal Strength: " + String(WiFi.RSSI()) + " dBm\n"
-                 "MAC Address: " + WiFi.macAddress() + "\n"
-                 "Gateway: " + WiFi.gatewayIP().toString() + "\n"
-                 "DNS: " + WiFi.dnsIP().toString() + "\n";
-  summary_item["text"] = status_text;
+  std::string text =
+      "IP Address: " + std::string(WiFi.localIP().toString().c_str()) + "\n"
+      "Signal Strength: " + std::to_string(WiFi.RSSI()) + " dBm\n"
+      "MAC Address: " + std::string(WiFi.macAddress().c_str()) + "\n"
+      "Gateway: " + std::string(WiFi.gatewayIP().toString().c_str()) + "\n"
+      "DNS: " + std::string(WiFi.dnsIP().toString().c_str()) + "\n";
 
-  // Return the parameters individually as structuredContent (MCP 2025-06-18+)
-  auto structured = result["structuredContent"].to<JsonObject>();
-  structured["ip_address"] = WiFi.localIP().toString();
-  structured["signal_strength_dbm"] = WiFi.RSSI();
-  structured["mac_address"] = WiFi.macAddress();
-  structured["gateway"] = WiFi.gatewayIP().toString();
-  structured["dns"] = WiFi.dnsIP().toString();
+  // Text summary plus the parameters individually as structuredContent (MCP 2025-06-18+)
+  mcp_response_schema r(response);
+  r.text(text)
+      .field("ip_address", WiFi.localIP().toString())
+      .field("signal_strength_dbm", WiFi.RSSI())
+      .field("mac_address", WiFi.macAddress())
+      .field("gateway", WiFi.gatewayIP().toString())
+      .field("dns", WiFi.dnsIP().toString());
 }
 
 void tool_system_status(mcp_response &response)
 {
-  auto result = response.create_result();
-  auto result_content = result["content"].to<JsonArray>();
-
   auto internal_temperature = (temprature_sens_read() - 32) / 1.8;
 
   // Human-readable text summary
-  auto summary_item = result_content.add<JsonObject>();
-  summary_item["type"] = "text";
-  auto status_text = String();
-  status_text.reserve(1024); // Pre-allocate to avoid repeated reallocations
-  status_text += "Uptime: " + String(millis() / 1000) + " seconds\n"
-                 "Free Heap: " + String(ESP.getFreeHeap()) + " bytes\n"
-                 "Min Free Heap: " + String(ESP.getMinFreeHeap()) + " bytes\n"
-                 "Max Alloc Heap: " + String(ESP.getMaxAllocHeap()) + " bytes\n"
-                 "CPU Frequency: " + String(getCpuFrequencyMhz()) + " MHz\n"
-                 "Flash Size: " + String(ESP.getFlashChipSize()) + " bytes\n"
-                 "Flash Speed: " + String(ESP.getFlashChipSpeed()) + " Hz\n"
-                 "Sketch Size: " + String(ESP.getSketchSize()) + " bytes\n"
-                 "Free Sketch Space: " + String(ESP.getFreeSketchSpace()) + " bytes\n"
-                 "SDK Version: " + String(ESP.getSdkVersion()) + "\n"
-                 "Reset Reason: " + String(esp_reset_reason()) + "\n"
-                 "Internal Temperature: " + String(internal_temperature, 2) + " °C\n";
-  summary_item["text"] = status_text;
+  std::string text =
+      "Uptime: " + std::to_string(millis() / 1000) + " seconds\n"
+      "Free Heap: " + std::to_string(ESP.getFreeHeap()) + " bytes\n"
+      "Min Free Heap: " + std::to_string(ESP.getMinFreeHeap()) + " bytes\n"
+      "Max Alloc Heap: " + std::to_string(ESP.getMaxAllocHeap()) + " bytes\n"
+      "CPU Frequency: " + std::to_string(getCpuFrequencyMhz()) + " MHz\n"
+      "Flash Size: " + std::to_string(ESP.getFlashChipSize()) + " bytes\n"
+      "Flash Speed: " + std::to_string(ESP.getFlashChipSpeed()) + " Hz\n"
+      "Sketch Size: " + std::to_string(ESP.getSketchSize()) + " bytes\n"
+      "Free Sketch Space: " + std::to_string(ESP.getFreeSketchSpace()) + " bytes\n"
+      "SDK Version: " + std::string(ESP.getSdkVersion()) + "\n"
+      "Reset Reason: " + std::to_string(esp_reset_reason()) + "\n"
+      "Internal Temperature: " + std::string(String(internal_temperature, 2).c_str()) + " °C\n";
 
-  // Return the parameters individually as structuredContent (MCP 2025-06-18+)
-  auto structured = result["structuredContent"].to<JsonObject>();
-  structured["uptime_seconds"] = millis() / 1000;
-  structured["free_heap_bytes"] = ESP.getFreeHeap();
-  structured["min_free_heap_bytes"] = ESP.getMinFreeHeap();
-  structured["max_alloc_heap_bytes"] = ESP.getMaxAllocHeap();
-  structured["cpu_frequency_mhz"] = getCpuFrequencyMhz();
-  structured["flash_size_bytes"] = ESP.getFlashChipSize();
-  structured["flash_speed_hz"] = ESP.getFlashChipSpeed();
-  structured["sketch_size_bytes"] = ESP.getSketchSize();
-  structured["free_sketch_space_bytes"] = ESP.getFreeSketchSpace();
-  structured["sdk_version"] = ESP.getSdkVersion();
-  structured["reset_reason"] = esp_reset_reason();
-  structured["internal_temperature_c"] = internal_temperature;
+  // Text summary plus the parameters individually as structuredContent (MCP 2025-06-18+)
+  mcp_response_schema r(response);
+  r.text(text)
+      .field("uptime_seconds", millis() / 1000)
+      .field("free_heap_bytes", ESP.getFreeHeap())
+      .field("min_free_heap_bytes", ESP.getMinFreeHeap())
+      .field("max_alloc_heap_bytes", ESP.getMaxAllocHeap())
+      .field("cpu_frequency_mhz", getCpuFrequencyMhz())
+      .field("flash_size_bytes", ESP.getFlashChipSize())
+      .field("flash_speed_hz", ESP.getFlashChipSpeed())
+      .field("sketch_size_bytes", ESP.getSketchSize())
+      .field("free_sketch_space_bytes", ESP.getFreeSketchSpace())
+      .field("sdk_version", ESP.getSdkVersion())
+      .field("reset_reason", esp_reset_reason())
+      .field("internal_temperature_c", internal_temperature);
 }
 
 void handle_tools_call(const mcp_request &request, mcp_response &response)
@@ -580,17 +503,14 @@ void handle_tools_call(const mcp_request &request, mcp_response &response)
   else
   {
     // Tool not found, set error
-    auto error = response.create_error();
     if (tool_name.isEmpty())
-    {
-      error["code"] = error_code::invalid_request;
-      error["message"] = "Tool name is required";
-    }
+      mcp_schema_error(response)
+        .code(error_code::invalid_request)
+        .message("Tool name is required");
     else
-    {
-      error["code"] = error_code::method_not_found;
-      error["message"] = "Unknown tool: " + tool_name;
-    }
+      mcp_schema_error(response)
+        .code(error_code::method_not_found)
+        .message(std::string(("Unknown tool: " + tool_name).c_str()));
   }
 }
 
@@ -656,17 +576,15 @@ void handleRoot()
     else if (mcp_request.method() == "tools/call")
       handle_tools_call(mcp_request, mcp_response);
     else
-    {
-      auto error = mcp_response.create_error();
-      error["code"] = error_code::method_not_found;
-      error["message"] = "Method not found: " + mcp_request.method();
-    }
+      mcp_schema_error(mcp_response)
+        .code(error_code::method_not_found)
+        .message(std::string(("Method not found: " + mcp_request.method()).c_str()));
   }
   catch (const mcp_exception &e)
   {
-    auto error = mcp_response.create_error();
-    error["code"] = e.code();
-    error["message"] = e.what();
+    mcp_schema_error(mcp_response)
+      .code(e.code())
+      .message(e.what());
   }
 
   auto response = mcp_response.get_http_response();
@@ -738,8 +656,6 @@ void setup()
   // Allow over the air updates (optionally password-protected)
   ArduinoOTA.setPassword(MCP_OTA_PASSWORD);
   ArduinoOTA.begin();
-
-  // Camera is initialized on demand inside tool_capture with the requested parameters
 
   // Register request headers to collect so hasHeader()/header() work for Accept-Encoding content negotiation
   const char *headerkeys[] = {"Accept-Encoding"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,26 +70,49 @@ static const std::map<std::string, int> camera_wb_modes = {
     {"Office", 3},
     {"Home", 4}};
 
+// ---------------------------------------------------------------------------
+// GPIO control tool configuration
+// ---------------------------------------------------------------------------
+// Pins that can be managed through the "gpio" tool, each paired with a dedicated
+// LEDC (PWM) channel used in analog output mode. Channels 10-15 live in LEDC
+// high-speed group 1 (timers 1-3) and never collide with the camera XCLK PWM,
+// which uses low-speed group 0 (timer 0 or 1, channel 0 or 1).
+static const std::map<int, uint8_t> gpio_pwm_channels = {
+    {2, 10},
+    {4, 11},  // FLASH LED
+    {12, 12},
+    {13, 13},
+    {14, 14},
+    {15, 15},
+    {33, 9}}; // RED LED
+
+// PWM settings for analog output mode (duty cycle given as a percentage).
+static constexpr uint32_t GPIO_PWM_FREQ = 5000;    // Hz
+static constexpr uint8_t GPIO_PWM_RESOLUTION = 8;  // bits -> duty 0..255
+static constexpr uint32_t GPIO_PWM_MAX_DUTY = 255; // (1 << resolution) - 1
+// Full-scale ADC reference (mV) used to express an analog input as a percentage.
+static constexpr uint32_t GPIO_ADC_REFERENCE_MV = 3300;
+
 // Minimal base64 encoder (RFC 4648), used to carry the SRTP master key and salt in the "a=crypto" attribute.
 std::string base64_encode(const uint8_t *data, size_t len)
 {
-    static const char table_b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    std::string out;
-    out.reserve(((len + 2) / 3) * 4);
-    for (size_t i = 0; i < len; i += 3)
-    {
-        auto n = (uint32_t)data[i] << 16;
-        if (i + 1 < len)
-            n |= (uint32_t)data[i + 1] << 8;
-        if (i + 2 < len)
-            n |= data[i + 2];
+  static const char table_b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  out.reserve(((len + 2) / 3) * 4);
+  for (size_t i = 0; i < len; i += 3)
+  {
+    auto n = (uint32_t)data[i] << 16;
+    if (i + 1 < len)
+      n |= (uint32_t)data[i + 1] << 8;
+    if (i + 2 < len)
+      n |= data[i + 2];
 
-        out += table_b64[(n >> 18) & 0x3f];
-        out += table_b64[(n >> 12) & 0x3f];
-        out += (i + 1 < len) ? table_b64[(n >> 6) & 0x3f] : '=';
-        out += (i + 2 < len) ? table_b64[n & 0x3f] : '=';
-    }
-    return out;
+    out += table_b64[(n >> 18) & 0x3f];
+    out += table_b64[(n >> 12) & 0x3f];
+    out += (i + 1 < len) ? table_b64[(n >> 6) & 0x3f] : '=';
+    out += (i + 2 < len) ? table_b64[n & 0x3f] : '=';
+  }
+  return out;
 }
 
 // Temperature export (funny; has a typo!)
@@ -190,20 +213,26 @@ void handle_tools_list(mcp_response &response)
 
   // Add LED control tool
   tool_schema led_tool(tools.add<JsonObject>(), "led", "Controls the ESP32-CAM LED state");
-  led_tool.boolean("on", "LED on", false).required("on");
+  led_tool
+    .boolean("on", "LED on", false)
+    .required("on");
 
   // Add flash control tool
   tool_schema flash_tool(tools.add<JsonObject>(), "flash", "Controls the ESP32-CAM Flash");
-  flash_tool.number("duration", "Flash duration in milliseconds", 5, 100, 50);
+  flash_tool
+    .number("duration", "Flash duration in milliseconds", 5, 100, 50);
 
   // Add camera capture tool
   tool_schema camera_tool(tools.add<JsonObject>(), "capture", "Captures a photo from the ESP32-CAM");
   camera_tool
       .boolean("flash", "Use flash when capturing", false)
-      .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes, [](framesize_t size) { return size == MCP_CAPTURE_FRAMESIZE; })
+      .enum_table("frame_size", "Resolution to use for the captured photo", frame_sizes, [](framesize_t size)
+                  { return size == MCP_CAPTURE_FRAMESIZE; })
       .number("quality", "JPEG quality for the captured photo (1-100)", 1, 100, MCP_CAPTURE_QUALITY)
-      .enum_table("whitebalance", "White balance mode for the captured photo", camera_wb_modes, [](int mode) { return mode == MCP_CAPTURE_WB_MODE; })
-      .enum_table("pixelformat", "Pixel format for the captured photo", pixel_formats, [](pixformat_t fmt) { return fmt == MCP_CAPTURE_PIXELFORMAT; });
+      .enum_table("whitebalance", "White balance mode for the captured photo", camera_wb_modes, [](int mode)
+                  { return mode == MCP_CAPTURE_WB_MODE; })
+      .enum_table("pixelformat", "Pixel format for the captured photo", pixel_formats, [](pixformat_t fmt)
+                  { return fmt == MCP_CAPTURE_PIXELFORMAT; });
 
   // Add WiFi status tool
   tool_schema wifi_tool(tools.add<JsonObject>(), "wifi_status",
@@ -219,6 +248,23 @@ void handle_tools_list(mcp_response &response)
                           "flash_speed_hz (integer), sketch_size_bytes (integer), free_sketch_space_bytes (integer), "
                           "sdk_version (string), reset_reason (integer), camera_initialized (boolean), "
                           "internal_temperature_c (number, °C)");
+
+  // Add GPIO control tool
+  tool_schema gpio_tool(tools.add<JsonObject>(), "gpio",
+                        "Controls the GPIO pins of the ESP32-CAM. "
+                        "Valid pins: 2, 4 (flash), 12, 13, 14, 15, 33 (red LED). "
+                        "Modes: di (digital input, returns value true/false from the logical level), "
+                        "ai (analog input, returns value 0-100, percentage of the calibrated max input), "
+                        "do (digital output, sets value true/false), "
+                        "ao (analog output, sets value 0-100, PWM duty cycle percentage). "
+                        "Note: analog input pins are ADC2 channels which are unavailable while Wi-Fi is "
+                        "active (readings may be 0).");
+  gpio_tool
+      .number("pin", "GPIO pin to control. Valid pins: 2, 4, 12, 13, 14, 15, 33")
+      .enum_string("mode", "Pin mode", {"di", "ai", "do", "ao"})
+      .any("value", "Required for output modes. do: true (HIGH) or false (LOW). ao: 0-100 (duty cycle percentage).")
+      .required("pin")
+      .required("mode");
 }
 
 void tool_led(JsonObject arguments, mcp_response &response)
@@ -299,8 +345,8 @@ void tool_capture(JsonObject arguments, mcp_response &response)
         valid_options += entry.first;
       }
       mcp_schema_error(response)
-        .code(error_code::invalid_params)
-        .message("Invalid whitebalance. Valid options: " + valid_options + ".");
+          .code(error_code::invalid_params)
+          .message("Invalid whitebalance. Valid options: " + valid_options + ".");
       return;
     }
     capture_whitebalance = wb_mode_it->second;
@@ -338,8 +384,8 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   if (camera_init_result != ESP_OK)
   {
     mcp_schema_error(response)
-        .code(error_code::internal_error)
-        .message("Camera initialization failed (0x" + std::string(String(camera_init_result, 16).c_str()) + ")");
+      .code(error_code::internal_error)
+      .message("Camera initialization failed (0x" + std::string(String(camera_init_result, 16).c_str()) + ")");
     return;
   }
 
@@ -365,7 +411,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   fb = esp_camera_fb_get();
   if (fb)
     esp_camera_fb_return(fb);
-else
+  else
     log_w("Capture: warm-up frame failed");
 
   // Take the actual frame
@@ -374,7 +420,7 @@ else
     log_d("Capture: captured frame: %u bytes, free heap after capture: %d", (unsigned)fb->len, ESP.getFreeHeap());
   else
     log_w("Capture: failed to capture frame, free heap after capture: %d", ESP.getFreeHeap());
-  
+
   // Turn flash off immediately after capture attempt
   digitalWrite(FLASH_GPIO, !FLASH_ON_LEVEL);
 
@@ -398,32 +444,51 @@ else
   // Resolve display names for the summary (reverse lookup over the maps)
   const char *frame_size_name = "Unknown";
   for (const auto &entry : frame_sizes)
-    if (entry.second == capture_framesize) { frame_size_name = entry.first.c_str(); break; }
+    if (entry.second == capture_framesize)
+    {
+      frame_size_name = entry.first.c_str();
+      break;
+    }
   const char *pixel_format_name = "Unknown";
   for (const auto &entry : pixel_formats)
-    if (entry.second == capture_pixelformat) { pixel_format_name = entry.first.c_str(); break; }
+    if (entry.second == capture_pixelformat)
+    {
+      pixel_format_name = entry.first.c_str();
+      break;
+    }
   const char *wb_mode_name = "Unknown";
   for (const auto &entry : camera_wb_modes)
-    if (entry.second == capture_whitebalance) { wb_mode_name = entry.first.c_str(); break; }
+    if (entry.second == capture_whitebalance)
+    {
+      wb_mode_name = entry.first.c_str();
+      break;
+    }
 
   // Human-readable text summary
   std::string text =
       "Image captured successfully. "
-      "Pixel format: " + std::string(pixel_format_name) + ", "
-      "Frame size: " + std::string(frame_size_name) + ", "
-      "Quality: " + std::to_string(capture_quality) + ", "
-      "White balance: " + std::string(wb_mode_name) + ", "
-      "Flash: " + std::string(arguments["flash"].as<bool>() ? "on" : "off") + ", "
-      "Dimensions: " + std::to_string(fb_width) + "x" + std::to_string(fb_height) + ", "
-      "Size: " + std::to_string(base64_image.length()) + " bytes (base64 encoded)";
+      "Pixel format: " +
+      std::string(pixel_format_name) + ", "
+                                       "Frame size: " +
+      std::string(frame_size_name) + ", "
+                                     "Quality: " +
+      std::to_string(capture_quality) + ", "
+                                        "White balance: " +
+      std::string(wb_mode_name) + ", "
+                                  "Flash: " +
+      std::string(arguments["flash"].as<bool>() ? "on" : "off") + ", "
+                                                                  "Dimensions: " +
+      std::to_string(fb_width) + "x" + std::to_string(fb_height) + ", "
+                                                                   "Size: " +
+      std::to_string(base64_image.length()) + " bytes (base64 encoded)";
 
   mcp_response_schema r(response);
   r.text(text)
-      .field("image", base64_image)
-      .field("format", pixel_format_name)
-      .field("width", fb_width)
-      .field("height", fb_height)
-      .field("mimeType", capture_pixelformat == PIXFORMAT_JPEG ? "image/jpeg" : "image/x-raw");
+    .field("image", base64_image)
+    .field("format", pixel_format_name)
+    .field("width", fb_width)
+    .field("height", fb_height)
+    .field("mimeType", capture_pixelformat == PIXFORMAT_JPEG ? "image/jpeg" : "image/x-raw");
   // The JSON document already holds its own copy of the image data
   base64_image.clear();
 }
@@ -433,19 +498,23 @@ void tool_wifi_status(mcp_response &response)
   // Human-readable text summary
   std::string text =
       "IP Address: " + std::string(WiFi.localIP().toString().c_str()) + "\n"
-      "Signal Strength: " + std::to_string(WiFi.RSSI()) + " dBm\n"
-      "MAC Address: " + std::string(WiFi.macAddress().c_str()) + "\n"
-      "Gateway: " + std::string(WiFi.gatewayIP().toString().c_str()) + "\n"
-      "DNS: " + std::string(WiFi.dnsIP().toString().c_str()) + "\n";
+                                                                        "Signal Strength: " +
+      std::to_string(WiFi.RSSI()) + " dBm\n"
+                                    "MAC Address: " +
+      std::string(WiFi.macAddress().c_str()) + "\n"
+                                               "Gateway: " +
+      std::string(WiFi.gatewayIP().toString().c_str()) + "\n"
+                                                         "DNS: " +
+      std::string(WiFi.dnsIP().toString().c_str()) + "\n";
 
   // Text summary plus the parameters individually as structuredContent (MCP 2025-06-18+)
   mcp_response_schema r(response);
   r.text(text)
-      .field("ip_address", WiFi.localIP().toString())
-      .field("signal_strength_dbm", WiFi.RSSI())
-      .field("mac_address", WiFi.macAddress())
-      .field("gateway", WiFi.gatewayIP().toString())
-      .field("dns", WiFi.dnsIP().toString());
+    .field("ip_address", WiFi.localIP().toString())
+    .field("signal_strength_dbm", WiFi.RSSI())
+    .field("mac_address", WiFi.macAddress())
+    .field("gateway", WiFi.gatewayIP().toString())
+    .field("dns", WiFi.dnsIP().toString());
 }
 
 void tool_system_status(mcp_response &response)
@@ -455,33 +524,165 @@ void tool_system_status(mcp_response &response)
   // Human-readable text summary
   std::string text =
       "Uptime: " + std::to_string(millis() / 1000) + " seconds\n"
-      "Free Heap: " + std::to_string(ESP.getFreeHeap()) + " bytes\n"
-      "Min Free Heap: " + std::to_string(ESP.getMinFreeHeap()) + " bytes\n"
-      "Max Alloc Heap: " + std::to_string(ESP.getMaxAllocHeap()) + " bytes\n"
-      "CPU Frequency: " + std::to_string(getCpuFrequencyMhz()) + " MHz\n"
-      "Flash Size: " + std::to_string(ESP.getFlashChipSize()) + " bytes\n"
-      "Flash Speed: " + std::to_string(ESP.getFlashChipSpeed()) + " Hz\n"
-      "Sketch Size: " + std::to_string(ESP.getSketchSize()) + " bytes\n"
-      "Free Sketch Space: " + std::to_string(ESP.getFreeSketchSpace()) + " bytes\n"
-      "SDK Version: " + std::string(ESP.getSdkVersion()) + "\n"
-      "Reset Reason: " + std::to_string(esp_reset_reason()) + "\n"
-      "Internal Temperature: " + std::string(String(internal_temperature, 2).c_str()) + " °C\n";
+                                                     "Free Heap: " +
+      std::to_string(ESP.getFreeHeap()) + " bytes\n"
+                                          "Min Free Heap: " +
+      std::to_string(ESP.getMinFreeHeap()) + " bytes\n"
+                                             "Max Alloc Heap: " +
+      std::to_string(ESP.getMaxAllocHeap()) + " bytes\n"
+                                              "CPU Frequency: " +
+      std::to_string(getCpuFrequencyMhz()) + " MHz\n"
+                                             "Flash Size: " +
+      std::to_string(ESP.getFlashChipSize()) + " bytes\n"
+                                               "Flash Speed: " +
+      std::to_string(ESP.getFlashChipSpeed()) + " Hz\n"
+                                                "Sketch Size: " +
+      std::to_string(ESP.getSketchSize()) + " bytes\n"
+                                            "Free Sketch Space: " +
+      std::to_string(ESP.getFreeSketchSpace()) + " bytes\n"
+                                                 "SDK Version: " +
+      std::string(ESP.getSdkVersion()) + "\n"
+                                         "Reset Reason: " +
+      std::to_string(esp_reset_reason()) + "\n"
+                                           "Internal Temperature: " +
+      std::string(String(internal_temperature, 2).c_str()) + " °C\n";
 
   // Text summary plus the parameters individually as structuredContent (MCP 2025-06-18+)
   mcp_response_schema r(response);
   r.text(text)
-      .field("uptime_seconds", millis() / 1000)
-      .field("free_heap_bytes", ESP.getFreeHeap())
-      .field("min_free_heap_bytes", ESP.getMinFreeHeap())
-      .field("max_alloc_heap_bytes", ESP.getMaxAllocHeap())
-      .field("cpu_frequency_mhz", getCpuFrequencyMhz())
-      .field("flash_size_bytes", ESP.getFlashChipSize())
-      .field("flash_speed_hz", ESP.getFlashChipSpeed())
-      .field("sketch_size_bytes", ESP.getSketchSize())
-      .field("free_sketch_space_bytes", ESP.getFreeSketchSpace())
-      .field("sdk_version", ESP.getSdkVersion())
-      .field("reset_reason", esp_reset_reason())
-      .field("internal_temperature_c", internal_temperature);
+    .field("uptime_seconds", millis() / 1000)
+    .field("free_heap_bytes", ESP.getFreeHeap())
+    .field("min_free_heap_bytes", ESP.getMinFreeHeap())
+    .field("max_alloc_heap_bytes", ESP.getMaxAllocHeap())
+    .field("cpu_frequency_mhz", getCpuFrequencyMhz())
+    .field("flash_size_bytes", ESP.getFlashChipSize())
+    .field("flash_speed_hz", ESP.getFlashChipSpeed())
+    .field("sketch_size_bytes", ESP.getSketchSize())
+    .field("free_sketch_space_bytes", ESP.getFreeSketchSpace())
+    .field("sdk_version", ESP.getSdkVersion())
+    .field("reset_reason", esp_reset_reason())
+    .field("internal_temperature_c", internal_temperature);
+}
+
+void tool_gpio(JsonObject arguments, mcp_response &response)
+{
+  // Resolve and validate the target pin
+  auto pin = arguments["pin"].as<int>();
+  auto channel_it = gpio_pwm_channels.find(pin);
+  if (channel_it == gpio_pwm_channels.end())
+  {
+    mcp_schema_error(response)
+      .code(error_code::invalid_params)
+      .message("Invalid or missing pin. Valid pins: 2, 12, 13, 14, 15.");
+    return;
+  }
+
+  // Resolve and validate the mode
+  if (arguments["mode"].isNull())
+  {
+    mcp_schema_error(response)
+      .code(error_code::invalid_params)
+      .message("Mode is required. Valid modes: di (digital input), ai (analog input), do (digital output), ao (analog output).");
+    return;
+  }
+  auto mode = arguments["mode"].as<String>();
+
+  if (mode == "di")
+  {
+    // Release the pin from any previously assigned PWM channel
+    ledcDetachPin(pin);
+    pinMode(pin, INPUT);
+    auto state = digitalRead(pin) == HIGH;
+    auto text = std::string("Pin GPIO") + std::to_string(pin) + " is digital input, level: " + (state ? "HIGH (true)" : "LOW (false)");
+    mcp_response_schema r(response);
+    r.text(text)
+      .field("pin", pin)
+      .field("mode", "di")
+      .field("value", state);
+  }
+  else if (mode == "ai")
+  {
+    // Release the pin from any previously assigned PWM channel
+    ledcDetachPin(pin);
+    pinMode(pin, ANALOG);
+    // analogReadMilliVolts applies the ADC calibration tables, giving a linear
+    // millivolt reading (0-3300 mV) instead of the raw, non-linear ADC count.
+    auto milli_volts = analogReadMilliVolts(pin);
+    auto percent = (float)milli_volts / (float)GPIO_ADC_REFERENCE_MV * 100.0f;
+    if (percent > 100.0f)
+      percent = 100.0f;
+    if (percent < 0.0f)
+      percent = 0.0f;
+
+    auto text = std::string("Pin GPIO") + std::to_string(pin) + " is analog input, value: " + std::to_string((int)(percent + 0.5f)) + "% (" + std::to_string(milli_volts) + " mV)";
+    mcp_response_schema r(response);
+    r.text(text)
+      .field("pin", pin)
+      .field("mode", "ai")
+      .field("value", percent)
+      .field("millivolts", milli_volts);
+  }
+  else if (mode == "do")
+  {
+    if (arguments["value"].isNull())
+    {
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Value (true/false) is required for do mode.");
+      return;
+    }
+    auto state = arguments["value"].as<bool>();
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, state ? HIGH : LOW);
+
+    auto text = std::string("Pin GPIO") + std::to_string(pin) + " set to " + (state ? "HIGH (true)" : "LOW (false)");
+    mcp_response_schema r(response);
+    r.text(text)
+      .field("pin", pin)
+      .field("mode", "do")
+      .field("value", state);
+  }
+  else if (mode == "ao")
+  {
+    if (arguments["value"].isNull())
+    {
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Value (0-100, duty cycle percentage) is required for ao mode.");
+      return;
+    }
+    auto percent = arguments["value"].as<float>();
+    if (percent < 0.0f || percent > 100.0f)
+    {
+      mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Value must be between 0 and 100 for ao mode.");
+      return;
+    }
+
+    auto channel = channel_it->second;
+    ledcSetup(channel, GPIO_PWM_FREQ, GPIO_PWM_RESOLUTION);
+    ledcAttachPin(pin, channel);
+    auto duty = (uint32_t)(percent / 100.0f * (float)GPIO_PWM_MAX_DUTY + 0.5f);
+    if (duty > GPIO_PWM_MAX_DUTY)
+      duty = GPIO_PWM_MAX_DUTY;
+    ledcWrite(channel, duty);
+
+    auto text = std::string("Pin GPIO") + std::to_string(pin) + " PWM duty set to " + std::to_string((int)(percent + 0.5f)) + "% (duty " + std::to_string(duty) + "/" + std::to_string(GPIO_PWM_MAX_DUTY) + ")";
+    mcp_response_schema r(response);
+    r.text(text)
+      .field("pin", pin)
+      .field("mode", "ao")
+      .field("value", percent)
+      .field("duty", duty)
+      .field("duty_max", GPIO_PWM_MAX_DUTY);
+  }
+  else
+  {
+    mcp_schema_error(response)
+        .code(error_code::invalid_params)
+        .message("Invalid mode. Valid modes: di, ai, do, ao.");
+  }
 }
 
 void handle_tools_call(const mcp_request &request, mcp_response &response)
@@ -500,6 +701,8 @@ void handle_tools_call(const mcp_request &request, mcp_response &response)
     tool_wifi_status(response);
   else if (tool_name == "system_status")
     tool_system_status(response);
+  else if (tool_name == "gpio")
+    tool_gpio(arguments, response);
   else
   {
     // Tool not found, set error
@@ -583,8 +786,8 @@ void handleRoot()
   catch (const mcp_exception &e)
   {
     mcp_schema_error(mcp_response)
-      .code(e.code())
-      .message(e.what());
+        .code(e.code())
+        .message(e.what());
   }
 
   auto response = mcp_response.get_http_response();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,6 +159,29 @@ const framesize_t lookup_frame_size(const char *pin)
     return FRAMESIZE_INVALID;
 }
 
+typedef struct
+{
+    const char name[7];
+    const int value;
+} camera_wb_mode_entry_t;
+
+constexpr const camera_wb_mode_entry_t camera_wb_modes[] = {
+    {"Auto", 0},
+    {"Sunny", 1},
+    {"Cloudy", 2},
+    {"Office", 3},
+    {"Home", 4}};
+
+const int lookup_camera_wb_mode(const char *name)
+{
+    // Lookup table for the white balance name to wb_mode int
+    for (const auto &entry : camera_wb_modes)
+        if (strncmp(entry.name, name, sizeof(entry.name)) == 0)
+            return entry.value;
+
+    return -1; // Not found
+}
+
 void handle_tools_list(mcp_response &response)
 {
   auto result = response.create_result();
@@ -220,6 +243,20 @@ void handle_tools_list(mcp_response &response)
     if (entry.frame_size == MCP_CAPTURE_FRAMESIZE)
       camera_tool_input_schema_properties_frame_size["default"] = entry.name;
   }
+  auto camera_tool_input_schema_properties_quality = camera_tool_input_schema_properties["quality"].to<JsonObject>();
+  camera_tool_input_schema_properties_quality["type"] = "number";
+  camera_tool_input_schema_properties_quality["description"] = "JPEG quality for the captured photo (1-100)";
+  camera_tool_input_schema_properties_quality["minimum"] = 1;
+  camera_tool_input_schema_properties_quality["maximum"] = 100;
+  camera_tool_input_schema_properties_quality["default"] = MCP_CAPTURE_QUALITY;
+  auto camera_tool_input_schema_properties_wb_mode = camera_tool_input_schema_properties["whitebalance"].to<JsonObject>();
+  camera_tool_input_schema_properties_wb_mode["type"] = "string";
+  camera_tool_input_schema_properties_wb_mode["description"] = "White balance mode for the captured photo";
+  auto camera_tool_input_schema_properties_wb_mode_enum = camera_tool_input_schema_properties_wb_mode["enum"].to<JsonArray>();
+  for (const auto &entry : camera_wb_modes)
+    camera_tool_input_schema_properties_wb_mode_enum.add(entry.name);
+  // Auto is the default white balance mode
+  camera_tool_input_schema_properties_wb_mode["default"] = camera_wb_modes[0].name;
   camera_tool_input_schema["additionalProperties"] = false;
 
   // Add WiFi status tool
@@ -297,7 +334,7 @@ void tool_capture(JsonObject arguments, mcp_response &response)
 
   // Resolve the requested capture resolution from the frame_size argument (enum)
   auto requested_framesize = FRAMESIZE_INVALID;
-  if (arguments.containsKey("frame_size"))
+  if (!arguments["frame_size"].isNull())
   {
     requested_framesize = lookup_frame_size(arguments["frame_size"].as<const char *>());
     if (requested_framesize == FRAMESIZE_INVALID)
@@ -326,6 +363,55 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   {
     log_d("Capture: setting resolution %d -> %d", sensor->status.framesize, capture_framesize);
     sensor->set_framesize(sensor, capture_framesize);
+  }
+
+  // Resolve the requested JPEG quality (1-100) from the quality argument
+  auto previous_quality = sensor ? sensor->status.quality : MCP_CAPTURE_QUALITY;
+  auto capture_quality = previous_quality;
+  if (!arguments["quality"].isNull())
+  {
+    auto quality = arguments["quality"].as<int>();
+    if (quality < 1 || quality > 100)
+    {
+      auto error = response.create_error();
+      error["code"] = error_code::invalid_params;
+      error["message"] = "Invalid quality. Must be between 1 and 100.";
+      return;
+    }
+    capture_quality = quality;
+  }
+  if (sensor && sensor->status.quality != capture_quality)
+  {
+    log_d("Capture: setting quality %d -> %d", sensor->status.quality, capture_quality);
+    sensor->set_quality(sensor, capture_quality);
+  }
+
+  // Resolve the requested white balance mode from the wb_mode argument (enum)
+  auto previous_whitebalance = sensor ? sensor->status.wb_mode : 0;
+  auto capture_whitebalance = previous_whitebalance;
+  if (!arguments["whitebalance"].isNull())
+  {
+    auto wb_mode = lookup_camera_wb_mode(arguments["whitebalance"].as<const char *>());
+    if (wb_mode < 0)
+    {
+      String valid_options;
+      for (const auto &entry : camera_wb_modes)
+      {
+        if (!valid_options.isEmpty())
+          valid_options += ", ";
+        valid_options += entry.name;
+      }
+      auto error = response.create_error();
+      error["code"] = error_code::invalid_params;
+      error["message"] = "Invalid whitebalance. Valid options: " + valid_options + ".";
+      return;
+    }
+    capture_whitebalance = wb_mode;
+  }
+  if (sensor && sensor->status.wb_mode != capture_whitebalance)
+  {
+    log_d("Capture: setting wb_mode %d -> %d", sensor->status.wb_mode, capture_whitebalance);
+    sensor->set_wb_mode(sensor, capture_whitebalance);
   }
   log_d("Capture: free heap before capture: %d", ESP.getFreeHeap());
 
@@ -379,6 +465,12 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   // Restore the previous capture resolution
   if (sensor && previous_framesize != capture_framesize)
     sensor->set_framesize(sensor, previous_framesize);
+  // Restore the previous capture quality
+  if (sensor && previous_quality != capture_quality)
+    sensor->set_quality(sensor, previous_quality);
+  // Restore the previous capture white balance mode
+  if (sensor && previous_whitebalance != capture_whitebalance)
+    sensor->set_wb_mode(sensor, previous_whitebalance);
 }
 
 void tool_wifi_status(mcp_response &response)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,9 @@ void handle_notifications_initialized(mcp_response &response)
   result["acknowledged"] = true;
 }
 
+// pixformat_t and the PIXFORMAT_* values are provided by esp_camera.h (sensor.h);
+// see the pixel_formats lookup table below.
+
 typedef struct frame_size_entry
 {
     const char name[17];
@@ -157,6 +160,35 @@ const framesize_t lookup_frame_size(const char *pin)
             return entry.frame_size;
 
     return FRAMESIZE_INVALID;
+}
+
+typedef struct pixel_format_entry
+{
+    const char name[12];
+    const pixformat_t pixel_format;
+} pixel_format_entry_t;
+
+constexpr const pixel_format_entry_t pixel_formats[] = {
+    {"RGB565", PIXFORMAT_RGB565},
+    {"YUV422", PIXFORMAT_YUV422},
+    {"YUV420", PIXFORMAT_YUV420},
+    {"Grayscale", PIXFORMAT_GRAYSCALE},
+    {"JPEG", PIXFORMAT_JPEG},
+    {"RGB888", PIXFORMAT_RGB888},
+    {"RAW", PIXFORMAT_RAW},
+    {"RGB444", PIXFORMAT_RGB444},
+    {"RGB555", PIXFORMAT_RGB555}};
+
+constexpr auto PIXFORMAT_INVALID = static_cast<pixformat_t>(0xff);
+
+const pixformat_t lookup_pixel_format(const char *pin)
+{
+    // Lookup table for the pixel format name to pixformat_t
+    for (const auto &entry : pixel_formats)
+        if (strncmp(entry.name, pin, sizeof(entry.name)) == 0)
+            return entry.pixel_format;
+
+    return PIXFORMAT_INVALID;
 }
 
 typedef struct
@@ -254,9 +286,23 @@ void handle_tools_list(mcp_response &response)
   camera_tool_input_schema_properties_wb_mode["description"] = "White balance mode for the captured photo";
   auto camera_tool_input_schema_properties_wb_mode_enum = camera_tool_input_schema_properties_wb_mode["enum"].to<JsonArray>();
   for (const auto &entry : camera_wb_modes)
+  {
     camera_tool_input_schema_properties_wb_mode_enum.add(entry.name);
+    if (entry.value == MCP_CAPTURE_WB_MODE)
+      camera_tool_input_schema_properties_wb_mode["default"] = entry.name;
+  }
   // Auto is the default white balance mode
   camera_tool_input_schema_properties_wb_mode["default"] = camera_wb_modes[0].name;
+  auto camera_tool_input_schema_properties_pixelformat = camera_tool_input_schema_properties["pixelformat"].to<JsonObject>();
+  camera_tool_input_schema_properties_pixelformat["type"] = "string";
+  camera_tool_input_schema_properties_pixelformat["description"] = "Pixel format for the captured photo";
+  auto camera_tool_input_schema_properties_pixelformat_enum = camera_tool_input_schema_properties_pixelformat["enum"].to<JsonArray>();
+  for (const auto &entry : pixel_formats)
+  {
+    camera_tool_input_schema_properties_pixelformat_enum.add(entry.name);
+    if (entry.pixel_format == MCP_CAPTURE_PIXELFORMAT)
+      camera_tool_input_schema_properties_pixelformat["default"] = entry.name;
+  }
   camera_tool_input_schema["additionalProperties"] = false;
 
   // Add WiFi status tool
@@ -413,6 +459,34 @@ void tool_capture(JsonObject arguments, mcp_response &response)
     log_d("Capture: setting wb_mode %d -> %d", sensor->status.wb_mode, capture_whitebalance);
     sensor->set_wb_mode(sensor, capture_whitebalance);
   }
+
+  // Resolve the requested pixel format from the pixelformat argument (enum)
+  auto previous_pixelformat = sensor ? sensor->pixformat : PIXFORMAT_JPEG;
+  auto capture_pixelformat = previous_pixelformat;
+  if (!arguments["pixelformat"].isNull())
+  {
+    auto pixel_format = lookup_pixel_format(arguments["pixelformat"].as<const char *>());
+    if (pixel_format == PIXFORMAT_INVALID)
+    {
+      String valid_options;
+      for (const auto &entry : pixel_formats)
+      {
+        if (!valid_options.isEmpty())
+          valid_options += ", ";
+        valid_options += entry.name;
+      }
+      auto error = response.create_error();
+      error["code"] = error_code::invalid_params;
+      error["message"] = "Invalid pixelformat. Valid options: " + valid_options + ".";
+      return;
+    }
+    capture_pixelformat = pixel_format;
+  }
+  if (sensor && sensor->pixformat != capture_pixelformat)
+  {
+    log_d("Capture: setting pixelformat %d -> %d", sensor->pixformat, capture_pixelformat);
+    sensor->set_pixformat(sensor, capture_pixelformat);
+  }
   log_d("Capture: free heap before capture: %d", ESP.getFreeHeap());
 
   auto flash = arguments["flash"].as<String>();
@@ -471,6 +545,9 @@ void tool_capture(JsonObject arguments, mcp_response &response)
   // Restore the previous capture white balance mode
   if (sensor && previous_whitebalance != capture_whitebalance)
     sensor->set_wb_mode(sensor, previous_whitebalance);
+  // Restore the previous capture pixel format
+  if (sensor && previous_pixelformat != capture_pixelformat)
+    sensor->set_pixformat(sensor, previous_pixelformat);
 }
 
 void tool_wifi_status(mcp_response &response)

--- a/test_cors.ps1
+++ b/test_cors.ps1
@@ -57,11 +57,11 @@ Write-Host ""
 Write-Host "2. Testing POST request with CORS headers:" -ForegroundColor Yellow
 
 $post_request = @{
-    jsonrpc = "2024-11-05"
+    jsonrpc = "2.0"
     id = 1
     method = "initialize"
     params = @{
-        protocolVersion = "2024-11-05"
+        protocolVersion = "2025-06-18"
         capabilities = @{}
         clientInfo = @{
             name = "CORS Test Client"

--- a/test_cors.sh
+++ b/test_cors.sh
@@ -18,11 +18,11 @@ curl -i -X POST "$ESP32_URL" \
   -H "Content-Type: application/json" \
   -H "Origin: http://localhost:3000" \
   -d '{
-    "jsonrpc": "2024-11-05",
+    "jsonrpc": "2.0",
     "id": 1,
     "method": "initialize",
     "params": {
-      "protocolVersion": "2024-11-05",
+      "protocolVersion": "2025-06-18",
       "capabilities": {},
       "clientInfo": {
         "name": "CORS Test Client",


### PR DESCRIPTION
# Changes: `main` → `develop`

**Branch:** `develop` is ahead of `main` by **10 commits** (2026-08-30 → 2026-08-31).
**Scale:** 19 files changed, **+1,538 / −445** lines.

## 🛠️ Firmware (`src/main.cpp`) — the bulk of the work (+920 lines)

- **New `gpio` tool** — read/write control of GPIO pins (2, 4, 12, 13, 14, 15, 33) with 4 modes:
  - `di` (digital input)
  - `ai` (analog input via ADC, 3.3 V reference)
  - `do` (digital output)
  - `ao` (analog output via LEDC PWM @ 5 kHz, 13-bit / 8191 duty → **sub-1% duty supported**)
- **`capture` tool enhancements** — resolution (`frame_size`), JPEG `quality` (1–100), `whitebalance` mode, and `pixelformat` are now per-request arguments with validation instead of fixed defaults
- **HTTP Basic authentication** for MCP requests (enabled when `MCP_API_USER` is set)
- **OTA updates** via ArduinoOTA (password-gated, disable-able)
- Memory usage optimization + watchdog handling

## ⚙️ New configuration header (`include/settings.h`)

Centralizes firmware config:

| Setting | Value |
|---------|-------|
| MCP protocol version | `2025-06-18` |
| Server name / version | `ESP32-CAM-AI MCP Server` / `1.0.1` |
| Capture defaults | VGA, JPEG, quality 20, WB auto |
| Watchdog | 30 s |
| Max request body | 16 KB |
| API credentials | `MCP_API_USER` / `MCP_API_PASSWORD` (empty = open access) |
| OTA password | `MCP_OTA_PASSWORD` |

## 📚 MCP library refactor (`lib/mcp/`)

- **New files:**
  - `mcp_schema_tool.h` — fluent tool-schema builder
  - `mcp_schema_error.h` — error helpers
  - `mcp_schema_response.h` — response helpers
- `mcp.h` / `mcp.cpp` migrated from Arduino `String` → **`std::string`**
- MCP protocol version bumped **2024-11-05 → 2025-06-18**; `jsonrpc` properly set to `"2.0"`

## 🔧 Build & CI

- `platformio.ini`:
  - platform pinned to `espressif32@7.0.1`
  - release optimization **`-O3` → `-O2`**
- `.github/workflows/main.yml`: added `timeout-minutes: 5` to the build job

## 🖥️ Browser controller (`browser_controller.html`)

- Capture section gained **flash, frame size, quality, white balance, and pixel format** controls
- New **GPIO Controls** panel (pin, mode, HIGH/LOW, analog duty %)
- Dynamic tool-option loading from the server's `tools/list` schema + text-return display

## 📄 Docs & scripts

- `QUICK_REFERENCE.md` — updated tool table (new `gpio`, revised `led`/`capture` args), protocol version, new PowerShell/curl examples (+160 lines)
- `README.md`, `PROJECT_DOCS.md`, `PROJECT_OVERVIEW.md` — feature/version updates
- `.env.template` — note pointing to `include/settings.h` for API credentials
- `capture_image.ps1/.sh`, `test_cors.ps1/.sh` — updated for new tool arguments (`flash` boolean, etc.)

## ⚠️ Breaking change to note

The `led` tool's `state: "on"/"off"` and `capture`'s `flash: "on"/"off"` arguments changed to **boolean** (`on: true/false`, `flash: true/false`), so existing MCP clients must update their payloads.